### PR TITLE
M1 OSS Foundation: trust docs, Dependabot, and security automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for this repository
+* @aytymchuk

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report a defect with a clear reproduction path
+title: "[Bug]: "
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Security issues must use [private vulnerability reporting](https://github.com/Dilcore-Official/Dilcore-MongoDb/security/advisories/new), not this form.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong in one or two sentences?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps or code that reproduce the issue.
+      placeholder: |
+        1. Configure ...
+        2. Call ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: Environment
+      description: .NET SDK, package version, MongoDB server/driver versions if known.
+      placeholder: net10.0, Dilcore.DocumentDb.MongoDb 1.x, MongoDB.Driver 3.5.2, MongoDB 7.0
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Logs, stack traces, or related roadmap issues (optional).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Dilcore-Official/Dilcore-MongoDb/security/advisories/new
+    about: Report security issues privately. Do not open a public issue.
+  - name: Questions and discussion
+    url: https://github.com/Dilcore-Official/Dilcore-MongoDb/discussions
+    about: Ask usage questions and discuss ideas in Discussions.
+  - name: Support policy
+    url: https://github.com/Dilcore-Official/Dilcore-MongoDb/blob/main/SUPPORT.md
+    about: Where to get help and what is in scope.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Propose a new capability or improvement
+title: "[Feature]: "
+labels: ["type:feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Check [ROADMAP.md](https://github.com/Dilcore-Official/Dilcore-MongoDb/blob/main/ROADMAP.md) before filing. Product positioning is an opinionated MongoDB toolkit — not a database-agnostic repository.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve for consumers?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the API or behavior you want.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds, existing driver APIs, or competing approaches.
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Samples, related issues, or acceptance criteria ideas (optional).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# Dependabot updates NuGet packages and GitHub Actions workflow references only.
+# Arbitrary YAML keys and non-ecosystem config values are out of scope.
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - area:dependencies
+      - type:chore
+    groups:
+      nuget-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - area:ci
+      - area:dependencies
+      - type:chore
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Related issues
+
+<!-- e.g. Fixes #123 / Relates to #8 -->
+
+## Checklist
+
+- [ ] I followed [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] Tests added or updated when behavior changes
+- [ ] Docs / ROADMAP / PublicAPI baselines updated when needed
+- [ ] No secrets or machine-specific paths committed
+- [ ] Security-sensitive changes called out for maintainer review
+
+## Test plan
+
+<!-- Commands you ran, e.g. `dotnet test test/UnitTests -c Release` -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,21 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: 🏗️ Build & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 🛠️ Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: 🧬 CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "17 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: 🧬 Analyze (C#)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v7
+
+      - name: 🛠️ Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: 🔧 Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+
+      - name: 🏗️ Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: 🧪 Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:csharp"

--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -1,0 +1,58 @@
+name: ✅ Config Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/dependabot.yml"
+      - ".github/ISSUE_TEMPLATE/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/dependabot.yml"
+      - ".github/ISSUE_TEMPLATE/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: ✅ Validate workflow and config YAML
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v7
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: 📦 Install check-jsonschema
+        run: pip install --disable-pip-version-check check-jsonschema
+
+      - name: 🔎 Validate Dependabot config
+        run: check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml
+
+      - name: 🔎 Validate GitHub workflows
+        run: check-jsonschema --builtin-schema vendor.github-workflows .github/workflows/*.yml
+
+      - name: 🔎 Validate issue forms
+        run: |
+          check-jsonschema --builtin-schema vendor.github-issue-forms \
+            .github/ISSUE_TEMPLATE/bug_report.yml \
+            .github/ISSUE_TEMPLATE/feature_request.yml
+          check-jsonschema --builtin-schema vendor.github-issue-config \
+            .github/ISSUE_TEMPLATE/config.yml
+
+      - name: ⬇️ Download actionlint
+        run: |
+          bash <(curl --proto '=https' --tlsv1.2 -sSf \
+            https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) \
+            1.7.12
+
+      - name: 🧪 Run actionlint
+        run: ./actionlint -color

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: 🔒 Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: 🔒 Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v7
+
+      - name: 🔎 Dependency Review
+        uses: actions/dependency-review-action@v5

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -44,7 +44,7 @@ jobs:
           PATCH=$((PATCH + 1))
           
           NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${NEW_VERSION}" >> "${GITHUB_OUTPUT}"
           echo "📦 New version: ${NEW_VERSION}"
 
       - name: 🛠️ Setup .NET

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -7,6 +7,9 @@ on:
       - 'src/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
@@ -16,13 +19,14 @@ jobs:
   publish:
     name: 🚀 Pack & Publish
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       packages: write
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -44,7 +48,7 @@ jobs:
           echo "📦 New version: ${NEW_VERSION}"
 
       - name: 🛠️ Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,46 @@
+name: 🏅 Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "31 4 * * 1"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: 🏅 Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: 📊 Run analysis
+        uses: ossf/scorecard-action@v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: 📤 Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: 🛡️ Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 bin/
 obj/
 /packages/
+
+# Locally downloaded actionlint binary (CI downloads its own copy)
+/actionlint
+/actionlint.exe
 riderModule.iml
 /_ReSharper.Caches/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+as described in [docs/policies/versioning-and-support.md](docs/policies/versioning-and-support.md).
+
+## [Unreleased]
+
+### Added
+
+- Open-source trust foundation: MIT `LICENSE`, contribution and security policies,
+  community templates, CODEOWNERS, Dependabot for NuGet and GitHub Actions, and
+  security automation (CodeQL, dependency review, Scorecard, workflow validation).
+
+## [1.0.0] - 2025
+
+### Added
+
+- Initial DocumentDB / MongoDB repository toolkit packages published under the
+  v1 package identity (`Dilcore.DocumentDb.*`).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[@aytymchuk](https://github.com/aytymchuk).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Thanks for contributing to **Dilcore MongoDB** (repository:
+[Dilcore-Official/Dilcore-MongoDb](https://github.com/Dilcore-Official/Dilcore-MongoDb)).
+
+Please read the [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
+
+## Ways to contribute
+
+| Kind | Channel |
+|------|---------|
+| Questions / ideas | [Discussions](https://github.com/Dilcore-Official/Dilcore-MongoDb/discussions) |
+| Bugs / features | [Issues](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/new/choose) (use the templates) |
+| Security reports | [Private vulnerability reporting](SECURITY.md) — never open a public issue |
+| Code / docs | Pull requests against `main` |
+
+Roadmap work is tracked in [ROADMAP.md](ROADMAP.md) and issues labeled `roadmap`.
+
+## Development setup
+
+Requirements:
+
+- .NET SDK **10.0.x**
+- Docker (only for integration tests that use Testcontainers)
+
+```bash
+dotnet restore
+dotnet build --configuration Release
+dotnet test test/UnitTests --configuration Release
+# Full suite (needs Docker):
+dotnet test --configuration Release
+```
+
+Roadmap issue hygiene (needs `gh` + `jq`):
+
+```bash
+./scripts/verify-roadmap-coverage.sh
+```
+
+## Pull requests
+
+1. Fork or branch from the latest `main`.
+2. Keep changes focused; match existing coding style and prefer reuse over
+   duplication.
+3. Update docs or PublicAPI baselines when you change public surface area.
+4. Fill out the pull request template and link related issues.
+5. Ensure required CI checks pass. Dependabot and other automation PRs still need
+   human review — there is no unconditional automerge.
+
+CODEOWNERS requests review from [@aytymchuk](https://github.com/aytymchuk).
+
+## Dependency updates
+
+- Dependabot opens weekly PRs for **NuGet** (`Directory.Packages.props` and
+  related manifests) and **GitHub Actions** workflow `uses:` references.
+- Major / breaking upgrades are left ungrouped so they can be reviewed alone.
+- Arbitrary YAML keys and non-ecosystem configuration are **out of scope** for
+  Dependabot and must be updated manually.
+- Prefer central package management and the rules in
+  [docs/policies/versioning-and-support.md](docs/policies/versioning-and-support.md).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,33 @@
+# Governance
+
+## Maintainers
+
+| Maintainer | GitHub |
+|------------|--------|
+| Arsen | [@aytymchuk](https://github.com/aytymchuk) |
+
+Maintainers have write access to the repository, merge authority for pull
+requests that pass required checks, and responsibility for releases, security
+triage, and roadmap prioritization.
+
+## Decision making
+
+- Day-to-day technical decisions are made by the maintainer(s) via pull request
+  review.
+- Product and breaking-change decisions for v2 are tracked as roadmap issues and
+  Architecture Decision Records under `docs/adr/`.
+- Community feedback is welcome through Issues and Discussions; consensus is
+  preferred, but the maintainer has final say when trade-offs are required.
+
+## Contributions
+
+Contributions are welcome under the [MIT License](LICENSE). See
+[CONTRIBUTING.md](CONTRIBUTING.md) for workflow, coding expectations, and pull
+request requirements. All participants must follow the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Escalation
+
+Security reports follow [SECURITY.md](SECURITY.md). Conduct issues may be
+reported to [@aytymchuk](https://github.com/aytymchuk) as described in the Code
+of Conduct.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dilcore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ A comprehensive .NET library providing a clean, abstracted interface for working
 
 > **v2 roadmap:** See [ROADMAP.md](ROADMAP.md) and [roadmap issues](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues?q=is%3Aissue+label%3Aroadmap) for the professional open-source redesign (milestones M0–M9). v2 renames the product to **Dilcore MongoDB** ([ADR 0001](docs/adr/0001-package-naming.md)).
 
+## Community and trust
+
+| Document | Purpose |
+|----------|---------|
+| [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute, develop, and open pull requests |
+| [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | Community standards |
+| [SECURITY.md](SECURITY.md) | Private vulnerability reporting |
+| [SUPPORT.md](SUPPORT.md) | Where to get help (Issues vs Discussions) |
+| [GOVERNANCE.md](GOVERNANCE.md) | Maintainers and decision making |
+| [CHANGELOG.md](CHANGELOG.md) | Notable changes |
+| [LICENSE](LICENSE) | MIT |
+
 ## 🏗️ Architecture Overview
 
 The library follows Clean Architecture principles with clear separation of concerns:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are applied to the actively maintained branch of this repository.
+See [docs/policies/versioning-and-support.md](docs/policies/versioning-and-support.md)
+for the supported target framework, MongoDB driver pin, and SemVer policy.
+
+| Version | Supported |
+|---------|-----------|
+| `main` / pre-v2 development | Yes |
+| Published v1 NuGet packages | Limited — critical fixes may be backported at maintainer discretion until v2 GA |
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security reports.**
+
+Use [GitHub private vulnerability reporting](https://github.com/Dilcore-Official/Dilcore-MongoDb/security/advisories/new)
+for this repository. Include:
+
+- Affected package(s) and versions when known
+- A clear description of the issue and impact
+- Steps to reproduce or a proof of concept when possible
+- Any known mitigations
+
+We aim to acknowledge reports within **7 days** and to provide a remediation
+plan or status update within **30 days**. Timing may vary with severity and
+upstream dependency constraints.
+
+## Dependency and automation scope
+
+- Dependabot maintains **NuGet** packages and **GitHub Actions** workflow
+  references (see [`.github/dependabot.yml`](.github/dependabot.yml) and
+  [#10](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/10)).
+- Dependabot does **not** update arbitrary YAML keys or non-ecosystem config
+  values; those remain manual.
+- Workflow Actions use stable version tags (for example `@v7`); Dependabot
+  bumps those tags on the weekly GitHub Actions schedule
+  ([#11](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/11)).
+- Automated checks include dependency review, CodeQL, OpenSSF Scorecard, and
+  workflow YAML validation. Findings appear in pull requests and the repository
+  Security tab when enabled.
+
+## Coordinated disclosure
+
+Please allow time for a fix and advisory before public disclosure. Credit will
+be given to reporters who wish to be named, unless they request anonymity.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,34 @@
+# Support
+
+## How to get help
+
+| Need | Where |
+|------|--------|
+| Usage questions, design discussion | [GitHub Discussions](https://github.com/Dilcore-Official/Dilcore-MongoDb/discussions) |
+| Bug reports | [GitHub Issues](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/new/choose) using the bug template |
+| Feature requests | [GitHub Issues](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/new/choose) using the feature template |
+| Security vulnerabilities | [Private vulnerability reporting](https://github.com/Dilcore-Official/Dilcore-MongoDb/security/advisories/new) — see [SECURITY.md](SECURITY.md) |
+| Roadmap and milestone tracking | [ROADMAP.md](ROADMAP.md) |
+
+## What we support
+
+- The actively developed `main` branch and published packages aligned with the
+  [versioning and support policy](docs/policies/versioning-and-support.md).
+- Issues that include a minimal, reproducible example when reporting defects.
+- Clarifying questions about documented APIs and configuration.
+
+## What we do not provide
+
+- Paid or SLA-backed commercial support.
+- Guaranteed response times for general questions.
+- Support for Amazon DocumentDB, Cosmos DB Mongo API, or other Mongo-compatible
+  services as first-class product targets (they may work when the MongoDB
+  driver does, but are not separately certified).
+- Private consulting through Issues or Discussions.
+
+## Discussions policy
+
+Use Discussions for Q&A, ideas, and show-and-tell. Prefer Issues for actionable
+defects and accepted feature work. Moderators may convert Issues to Discussions
+(or the reverse) when the category is a better fit. Follow the
+[Code of Conduct](CODE_OF_CONDUCT.md) in all channels.


### PR DESCRIPTION
## Summary

Implements **[M1 OSS Foundation](https://github.com/Dilcore-Official/Dilcore-MongoDb/milestone/2)** so the repository has the open-source trust, community, dependency, and security baseline required before M2 package/DI work.

**Why:** Preview/GA gates require a public MIT license, contribution/security policies, Dependabot for NuGet + GitHub Actions, and security automation with CI as a required check. This PR lands those deliverables without changing product APIs or packages.

**What:**
- Trust documents: MIT `LICENSE`, `CONTRIBUTING`, `CODE_OF_CONDUCT`, `SECURITY`, `SUPPORT`, `GOVERNANCE`, `CHANGELOG`, plus README discovery links
- Community: issue/PR templates, `CODEOWNERS` (`@aytymchuk`), Discussions policy in SUPPORT/CONTRIBUTING
- Dependabot: weekly NuGet + GitHub Actions updates with bounded PRs and minor/patch grouping
- Security workflows: CodeQL, dependency review, OpenSSF Scorecard, config validation (`actionlint` + `check-jsonschema`)
- CI/NuGet publish: least-privilege permissions, timeouts, latest stable action tags with emoji naming
- Repo settings (already applied): Discussions, private vulnerability reporting, Dependabot security updates, `Protect main` ruleset requiring `🏗️ Build & Test`

### Issues / milestone

Milestone: [M1 OSS Foundation](https://github.com/Dilcore-Official/Dilcore-MongoDb/milestone/2)

- Closes #8 — OSS trust documents
- Closes #9 — Community templates, CODEOWNERS, required CI rulesets
- Closes #10 — Dependabot for NuGet and GitHub Actions
- Closes #11 — Security automation (CodeQL, Scorecard, YAML validation)

## Test plan

- [x] No commit-SHA action pins under `.github/workflows/`
- [x] `check-jsonschema` for Dependabot, workflows, and issue forms
- [x] `actionlint` on all workflows
- [x] `./scripts/verify-roadmap-coverage.sh`
- [x] `dotnet build --configuration Release`
- [x] `dotnet test test/UnitTests --configuration Release` (9 passed)
- [x] GitHub Actions on this PR: CI, Config Validation, CodeQL, Dependency Review

## Verification status

### Local

| Check | Result |
|-------|--------|
| Action SHA pin scan | PASS |
| check-jsonschema (dependabot + workflows + issue forms) | PASS |
| actionlint 1.7.12 | PASS |
| Roadmap coverage `#2–#46` | PASS |
| `dotnet build -c Release` | PASS (0 errors; existing NU19xx advisories unchanged) |
| Unit tests | PASS (9/9) |
| Discussions enabled | PASS |
| Private vulnerability reporting | PASS |
| Dependabot security updates | PASS |
| Ruleset `Protect main` → `🏗️ Build & Test` | PASS |

### GitHub Actions (head `d0e5307`)

| Check | Result | Link |
|-------|--------|------|
| 🏗️ Build & Test | PASS | [run](https://github.com/Dilcore-Official/Dilcore-MongoDb/actions/runs/30762522380/job/91535497058) |
| ✅ Validate workflow and config YAML | PASS | [run](https://github.com/Dilcore-Official/Dilcore-MongoDb/actions/runs/30762522393/job/91535497199) |
| 🔒 Dependency Review | PASS | [run](https://github.com/Dilcore-Official/Dilcore-MongoDb/actions/runs/30762522377/job/91535497109) |
| 🧬 Analyze (C#) | PASS | [run](https://github.com/Dilcore-Official/Dilcore-MongoDb/actions/runs/30762522401/job/91535497184) |
| CodeQL | PASS | [run](https://github.com/Dilcore-Official/Dilcore-MongoDb/runs/91535730463) |
| CodeRabbit | PASS (rate limited) | — |

Note: first Config Validation run failed on unquoted `$GITHUB_OUTPUT` in `nuget-publish.yml` (shellcheck SC2086); fixed in `d0e5307`.