### PR TITLE
feat: Enhance document entity model with typed identifiers and option…

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -93,6 +93,15 @@ jobs:
           print(f"Benchmarks: {len(merged.get('Benchmarks', []))}")
           PY
 
+      - name: 🔎 Check gh-pages branch
+        id: gh_pages
+        run: |
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: 📈 Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -106,3 +115,4 @@ jobs:
           fail-on-alert: false
           alert-threshold: '150%'
           summary-always: true
+          skip-fetch-gh-pages: ${{ steps.gh_pages.outputs.exists != 'true' }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -67,7 +67,9 @@ jobs:
           python3 <<'PY'
           import glob
           import json
+          import os
           import sys
+          from pathlib import Path
 
           files = sorted(
               path for path in glob.glob("BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json")
@@ -91,7 +93,61 @@ jobs:
               json.dump(merged, handle)
           print(f"Merged {len(files)} report(s) into {out}")
           print(f"Benchmarks: {len(merged.get('Benchmarks', []))}")
+
+          markdown_files = sorted(
+              glob.glob("BenchmarkDotNet.Artifacts/results/*-report-github.md")
+          )
+          if not markdown_files:
+              print("No *-report-github.md files found", file=sys.stderr)
+              sys.exit(1)
+
+          summary = "## 📊 Benchmark results\n\n" + "\n\n".join(
+              Path(path).read_text(encoding="utf-8")
+              for path in markdown_files
+          )
+          summary_path = Path("BenchmarkDotNet.Artifacts/results/benchmark-summary.md")
+          summary_path.write_text(summary, encoding="utf-8")
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write(summary)
+              handle.write("\n")
           PY
+
+      - name: 💬 Publish benchmark PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        env:
+          BENCHMARK_SUMMARY_PATH: test/Benchmarks/Dilcore.MongoDB.Benchmarks/BenchmarkDotNet.Artifacts/results/benchmark-summary.md
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- dilcore-benchmark-results -->';
+            const summary = fs.readFileSync(process.env.BENCHMARK_SUMMARY_PATH, 'utf8');
+            const body = `${marker}\n${summary}\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100
+            });
+            const existing = comments.find(comment =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }
 
       - name: 📈 Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
@@ -101,8 +157,6 @@ jobs:
           output-file-path: test/Benchmarks/Dilcore.MongoDB.Benchmarks/BenchmarkDotNet.Artifacts/results/combined-report-full-compressed.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          comment-always: ${{ github.event_name == 'pull_request' }}
           comment-on-alert: true
           fail-on-alert: false
           alert-threshold: '150%'
-          summary-always: true

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,108 @@
+name: 📊 Benchmarks
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'test/Benchmarks/**'
+      - 'Directory.Packages.props'
+      - '.github/workflows/benchmarks.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'test/Benchmarks/**'
+      - 'Directory.Packages.props'
+      - '.github/workflows/benchmarks.yml'
+
+permissions:
+  contents: write
+  deployments: write
+  pull-requests: write
+
+jobs:
+  benchmarks:
+    name: 🏃 Performance Benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v7
+
+      - name: 🛠️ Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: 🐳 Docker preflight
+        run: |
+          docker version
+          docker info
+
+      - name: 📦 Restore dependencies
+        run: dotnet restore test/Benchmarks/Dilcore.MongoDB.Benchmarks/Dilcore.MongoDB.Benchmarks.csproj
+
+      - name: 🔨 Build
+        run: >
+          dotnet build test/Benchmarks/Dilcore.MongoDB.Benchmarks/Dilcore.MongoDB.Benchmarks.csproj
+          --no-restore
+          --configuration Release
+
+      - name: 🏃 Run benchmarks
+        working-directory: test/Benchmarks/Dilcore.MongoDB.Benchmarks
+        run: >
+          dotnet run
+          --no-build
+          --configuration Release
+          --no-launch-profile
+          --
+          --filter '*'
+          --exporters json
+
+      - name: 🧩 Merge BenchmarkDotNet reports
+        working-directory: test/Benchmarks/Dilcore.MongoDB.Benchmarks
+        run: |
+          python3 <<'PY'
+          import glob
+          import json
+          import sys
+
+          files = sorted(
+              path for path in glob.glob("BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json")
+              if "combined-report" not in path
+          )
+          if not files:
+              print("No *-report-full-compressed.json files found", file=sys.stderr)
+              sys.exit(1)
+
+          merged = None
+          for path in files:
+              with open(path, encoding="utf-8") as handle:
+                  data = json.load(handle)
+              if merged is None:
+                  merged = data
+              else:
+                  merged.setdefault("Benchmarks", []).extend(data.get("Benchmarks", []))
+
+          out = "BenchmarkDotNet.Artifacts/results/combined-report-full-compressed.json"
+          with open(out, "w", encoding="utf-8") as handle:
+              json.dump(merged, handle)
+          print(f"Merged {len(files)} report(s) into {out}")
+          print(f"Benchmarks: {len(merged.get('Benchmarks', []))}")
+          PY
+
+      - name: 📈 Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Dilcore.MongoDB Benchmarks
+          tool: benchmarkdotnet
+          output-file-path: test/Benchmarks/Dilcore.MongoDB.Benchmarks/BenchmarkDotNet.Artifacts/results/combined-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          comment-always: ${{ github.event_name == 'pull_request' }}
+          comment-on-alert: true
+          fail-on-alert: false
+          alert-threshold: '150%'
+          summary-always: true

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -93,15 +93,6 @@ jobs:
           print(f"Benchmarks: {len(merged.get('Benchmarks', []))}")
           PY
 
-      - name: 🔎 Check gh-pages branch
-        id: gh_pages
-        run: |
-          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: 📈 Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -115,4 +106,3 @@ jobs:
           fail-on-alert: false
           alert-threshold: '150%'
           summary-always: true
-          skip-fetch-gh-pages: ${{ steps.gh_pages.outputs.exists != 'true' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Roadmap work is tracked in [ROADMAP.md](ROADMAP.md) and issues labeled `roadmap`
 Requirements:
 
 - .NET SDK **10.0.x**
-- Docker (only for integration tests that use Testcontainers)
+- Docker (for integration tests and benchmarks that use Testcontainers)
 
 ```bash
 dotnet restore Dilcore.MongoDB.sln
@@ -32,6 +32,10 @@ dotnet test test/ArchitectureTests --configuration Release
 dotnet test test/IntegrationTests --configuration Release
 # Full suite:
 dotnet test Dilcore.MongoDB.sln --configuration Release
+# Performance benchmarks (needs Docker for repository/bulk/projection tiers):
+dotnet run --project test/Benchmarks/Dilcore.MongoDB.Benchmarks -c Release -- --filter '*'
+# Cold-start only (no Docker):
+dotnet run --project test/Benchmarks/Dilcore.MongoDB.Benchmarks -c Release -- --filter '*ColdStart*'
 ```
 
 Use **Shouldly** for assertions (not FluentAssertions). Architecture tests enforce the
@@ -39,6 +43,11 @@ two-package topology and dependency boundaries without Docker. DI acceptance tes
 build the container with `ValidateScopes` / `ValidateOnBuild` via
 `AcceptanceServiceProviderFactory`. CI runs a dedicated Architecture Tests job and a
 DI Acceptance job (Docker preflight) as required checks alongside the full Build & Test job.
+The **Benchmarks** workflow (`.github/workflows/benchmarks.yml`) runs BenchmarkDotNet on
+PRs that touch `src/` or `test/Benchmarks/`, posts a non-blocking results comment, and
+updates the historical baseline on `main` via `gh-pages`. Create an empty `gh-pages`
+branch once if it does not exist yet (`git checkout --orphan gh-pages && git commit
+--allow-empty -m "bench history" && git push -u origin gh-pages`).
 
 Roadmap issue hygiene (needs `gh` + `jq`):
 

--- a/Dilcore.MongoDB.sln
+++ b/Dilcore.MongoDB.sln
@@ -31,6 +31,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{5D20
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoDb.WebApi.Sample", "samples\MongoDb.WebApi.Sample\MongoDb.WebApi.Sample.csproj", "{4FEF58E8-1E3F-4552-92A5-D6671BBCAEE4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{66320409-64EC-F7C5-3DEF-65E7510DAAD1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dilcore.MongoDB.Benchmarks", "test\Benchmarks\Dilcore.MongoDB.Benchmarks\Dilcore.MongoDB.Benchmarks.csproj", "{AD42E8AE-9C12-45A7-892F-C939C04746C8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +129,18 @@ Global
 		{4FEF58E8-1E3F-4552-92A5-D6671BBCAEE4}.Release|x64.Build.0 = Release|Any CPU
 		{4FEF58E8-1E3F-4552-92A5-D6671BBCAEE4}.Release|x86.ActiveCfg = Release|Any CPU
 		{4FEF58E8-1E3F-4552-92A5-D6671BBCAEE4}.Release|x86.Build.0 = Release|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Debug|x64.Build.0 = Debug|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Debug|x86.Build.0 = Debug|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Release|x64.ActiveCfg = Release|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Release|x64.Build.0 = Release|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Release|x86.ActiveCfg = Release|Any CPU
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -141,5 +157,6 @@ Global
 		{F48A9F05-D3C3-4D5F-81DF-E9F1D356713F} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
 		{8E3A9C28-3A07-407F-8DE5-8772D03D19EA} = {F48A9F05-D3C3-4D5F-81DF-E9F1D356713F}
 		{4FEF58E8-1E3F-4552-92A5-D6671BBCAEE4} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
+		{AD42E8AE-9C12-45A7-892F-C939C04746C8} = {66320409-64EC-F7C5-3DEF-65E7510DAAD1}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.NUnit4" Version="4.19.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/README.md
+++ b/README.md
@@ -441,6 +441,26 @@ The library includes comprehensive test suites demonstrating various usage patte
 ### Unit Tests
 - **DocumentEntityExtensionsTests**: Entity extension methods and utilities
 
+### Benchmarks
+Performance suite under `test/Benchmarks/Dilcore.MongoDB.Benchmarks` (BenchmarkDotNet):
+
+- **ColdStartBenchmarks**: DI registration + first resolve vs raw `MongoClient`
+- **RepositoryCrudBenchmarks**: Store / Get / GetList / streaming / Count / HasAny / soft & hard delete vs raw driver
+- **BulkRepositoryBenchmarks**: `BulkStoreAsync` / `BulkDeleteAsync` at batch sizes 100 and 1000
+- **ProjectionRepositoryBenchmarks**: typed projection get/list vs raw driver projections
+
+Telemetry on/off overhead (v2 budgets ≤1% / ≤3%) is deferred until M6 (`#33` / `#34`).
+
+```bash
+# Full suite (Docker required for CRUD / bulk / projection):
+dotnet run --project test/Benchmarks/Dilcore.MongoDB.Benchmarks -c Release -- --filter '*'
+
+# Cold-start only (no Docker):
+dotnet run --project test/Benchmarks/Dilcore.MongoDB.Benchmarks -c Release -- --filter '*ColdStart*'
+```
+
+CI workflow [`.github/workflows/benchmarks.yml`](.github/workflows/benchmarks.yml) posts results as a PR comment (non-blocking) and stores history on `gh-pages` when merging to `main`.
+
 ### Test Infrastructure
 The tests use Testcontainers for MongoDB to provide isolated, reproducible test environments:
 

--- a/README.md
+++ b/README.md
@@ -66,17 +66,55 @@ The library follows Clean Architecture principles with clear separation of conce
 
 ### Document Entity Interface
 
-All entities must implement `IDocumentEntity`:
+Documents implement `IDocumentEntity<TId>` for a typed identifier. Optional policies are composed independently:
 
 ```csharp
-public interface IDocumentEntity
+public interface IDocumentEntity { }
+
+public interface IDocumentEntity<TId> : IDocumentEntity
 {
-    Guid Id { get; set; }
-    long ETag { get; set; }
-    bool IsDeleted { get; set; }
+    TId Id { get; set; }
+}
+
+public interface IHasConcurrencyToken { long ETag { get; set; } }
+public interface ISoftDeletable { bool IsDeleted { get; set; } }
+public interface IAuditableDocument
+{
     DateTime CreatedAt { get; set; }
     DateTime UpdatedAt { get; set; }
 }
+```
+
+Minimal document:
+
+```csharp
+public class Note : IDocumentEntity<Guid>
+{
+    public Guid Id { get; set; }
+    public string Text { get; set; } = "";
+}
+```
+
+Fully composed document (concurrency + soft delete + audit):
+
+```csharp
+public class WeatherForecast : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
+{
+    public Guid Id { get; set; }
+    public long ETag { get; set; }
+    public bool IsDeleted { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    // domain properties...
+}
+```
+
+For `Guid` identifiers, opt into RFC 9562 UUID v7 generation per binding:
+
+```csharp
+db.AddDocumentBinding<WeatherForecast>("weather", d => d
+    .WithCollectionName("weatherForecasts")
+    .WithGuidIdGeneration(GuidIdGenerationStrategy.SequentialVersion7));
 ```
 
 ### Repository Types
@@ -259,15 +297,23 @@ app.MapPost("/weather-forecasts", async (IGenericRepository<WeatherForecast> rep
 ### Entity Definition
 
 ```csharp
-public record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary) : IDocumentEntity
+// Fully composed: identifier + concurrency + soft delete + audit
+public record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+    : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
 {
     public Guid Id { get; set; }
     public long ETag { get; set; }
     public bool IsDeleted { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
-    
+
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}
+
+// Minimal: identifier only
+public record Note(string Text) : IDocumentEntity<Guid>
+{
+    public Guid Id { get; set; }
 }
 ```
 
@@ -447,15 +493,22 @@ repositoryOptions.WithBulkRepository()             // Enable bulk operations
 
 2. **Define your entities**:
    ```csharp
-   public class MyEntity : IDocumentEntity
+   // Minimal
+   public class MyEntity : IDocumentEntity<Guid>
+   {
+       public Guid Id { get; set; }
+       public string Name { get; set; }
+       public string Description { get; set; }
+   }
+
+   // Or compose optional policies
+   public class MyAuditedEntity : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
    {
        public Guid Id { get; set; }
        public long ETag { get; set; }
        public bool IsDeleted { get; set; }
        public DateTime CreatedAt { get; set; }
        public DateTime UpdatedAt { get; set; }
-       
-       // Your custom properties
        public string Name { get; set; }
        public string Description { get; set; }
    }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -212,7 +212,7 @@ Milestone: [M5 Quality & Packaging](https://github.com/Dilcore-Official/Dilcore-
 | [#28](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/28) | `global.json`, `.editorconfig`, analyzers, XML docs, warnings-as-errors, format gate | P0 |
 | [#29](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/29) | Consolidate tests on NUnit + Shouldly; expand unit/integration/public-API suites | P0 |
 | [#30](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/30) | Package validation, Source Link, symbols, OIDC NuGet publish; `PackageDescription`/tags match [package-descriptions](docs/product/package-descriptions.md) | P0 |
-| [#31](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/31) | Benchmarks: driver vs policy, DI, JSON, transactions, streaming, telemetry overhead | P1 |
+| [#31](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/31) | Benchmarks: initial suite (cold-start, CRUD, bulk, projections) in CI with non-blocking PR comments; telemetry / JSON / transactions / streaming overhead still pending M3–M6 | P1 |
 
 **Exit criteria:** Deterministic builds; package validation green; main-branch auto-publish removed; Shouldly remains the assertion library.
 

--- a/docs/adr/0002-generic-document-identifier.md
+++ b/docs/adr/0002-generic-document-identifier.md
@@ -1,0 +1,66 @@
+# ADR 0002: Generic document identifier and composable entity policies
+
+- **Status:** Accepted
+- **Date:** 2026-08-18
+- **Issue:** [#60](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/60)
+- **Blocks:** [#61](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/61), [#62](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/62)
+
+## Context
+
+`IDocumentEntity` currently hardcodes `Guid Id` and forces every document to carry `ETag`, `IsDeleted`, `CreatedAt`, and `UpdatedAt`. Consumers need `ObjectId`, `string`, `long`, or custom value-type identifiers, and many documents need only a subset of the policy properties. The design principle already states that optional policies should be composable interfaces rather than one mandatory entity shape. Repositories (`IGenericRepository<TDocument>` and friends), DI bindings, and the collection factory must keep working through a single generic-repository pattern without requiring a second type argument at every call site.
+
+## Decision drivers
+
+- Support any identifier type while preserving `IGenericRepository<TDocument>` (one type argument).
+- Keep repositories, serialization, and BSON `_id` conventions strongly typed where possible.
+- Prefer a clean break: no v1 shims (see [versioning policy](../policies/versioning-and-support.md) and ROADMAP non-goals).
+- Stay compatible with the M2 named-binding / DI model.
+- Allow Guid consumers to opt into RFC 9562 UUID version 7 generation without changing BSON representation.
+
+## Options considered
+
+| Option | Summary | Rejected because |
+|--------|---------|------------------|
+| A. `IDocumentEntity<TId>` only; repositories become `IGenericRepository<TDocument, TId>` | Fully static typing everywhere | Extra `TId` at every binding/repository call site; larger public API break for little consumer benefit |
+| B. Non-generic `object Id` / `BsonValue Id` | Single type argument preserved | Loses type safety; poor ergonomics for filters and helpers |
+| **C. Marker `IDocumentEntity` + `IDocumentEntity<TId>`; repositories stay single-generic** | Internal id-accessor cache resolves `TId` once per document type | **Accepted** |
+
+## Decision
+
+### Identifier shape
+
+- `IDocumentEntity` becomes an empty marker interface.
+- `IDocumentEntity<TId>` extends the marker and exposes `TId Id { get; set; }`.
+- Generic repositories, collection factory, and DI builders remain constrained to `where TDocument : class, IDocumentEntity` (marker only).
+- An internal per-`TDocument` id accessor cache resolves the closed `IDocumentEntity<TId>`, provides `IsEmpty` / `EnsureNewId` / `BuildIdFilter`, and is cached in a `ConcurrentDictionary`. Built-in generators cover `Guid` and `ObjectId`; unsupported `TId` types throw a clear exception instructing callers to assign `Id` before `StoreAsync`.
+
+### Guid generation
+
+- Default remains `Guid.NewGuid()` (UUID v4) via `GuidIdGenerationStrategy.Random`.
+- Consumers may opt into `Guid.CreateVersion7()` (UUID v7) per document binding with `WithGuidIdGeneration(GuidIdGenerationStrategy.SequentialVersion7)`.
+- BSON wire format is unchanged (`GuidRepresentation.Standard`); only generation differs.
+
+### Policy interfaces (implemented with [#61](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/61))
+
+Independent, opt-in interfaces composed on concrete document types:
+
+| Interface | Members |
+|-----------|---------|
+| `IHasConcurrencyToken` | `long ETag` |
+| `ISoftDeletable` | `bool IsDeleted` |
+| `IAuditableDocument` | `DateTime CreatedAt`, `DateTime UpdatedAt` |
+
+Repository soft-delete filtering, ETag concurrency, and audit stamping activate only when the corresponding interface is implemented. DI features such as `WithSoftDelete()` and `WithGuidIdGeneration(...)` fail closed at registration when the document type lacks the required capability.
+
+### Serialization / BSON id conventions
+
+- Property named `Id` continues to map to `_id` via driver conventions; `[BsonId]` is not required.
+- Existing `GuidSerializer(GuidRepresentation.Standard)` registration remains process-wide and is independent of UUID version.
+
+## Consequences
+
+- Hard breaking change to `IDocumentEntity` and related public surface; no compatibility shims.
+- Call sites that previously assumed `Guid Id` / mandatory ETag / soft-delete / audit properties must compose the new interfaces explicitly.
+- Public API baseline (`PublicAPI.*.txt`, `docs/api/v1-public-api.md`), README, and samples must be updated in the same milestone.
+- Small one-time reflection cost per document type at first id-accessor resolution; hot paths use the cached typed accessor.
+- `GenericRepositoryExtensions` helpers that take `Guid id` constrain to `IDocumentEntity<Guid>`; ETag-aware delete helpers also require `IHasConcurrencyToken`.

--- a/docs/api/v1-public-api.md
+++ b/docs/api/v1-public-api.md
@@ -128,3 +128,24 @@ Internal (not in baseline as public API): `MongoClientProvider`, `MongoCollectio
 5. Public mutable `MongoDatabaseContainer.Services` service-locator field.
 
 These feed the [defect inventory](../product/v1-defects.md) and [#13](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/13).
+
+---
+
+## M2.5 update (v2 entity model)
+
+As of [ADR 0002](../adr/0002-generic-document-identifier.md) / milestone M2.5:
+
+| Type | Change |
+|------|--------|
+| `IDocumentEntity` | Empty marker (no longer carries `Guid Id` / ETag / soft-delete / audit members) |
+| `IDocumentEntity<TId>` | Typed identifier contract |
+| `IHasConcurrencyToken` | Opt-in `ETag` |
+| `ISoftDeletable` | Opt-in `IsDeleted` |
+| `IAuditableDocument` | Opt-in `CreatedAt` / `UpdatedAt` |
+| `GuidIdGenerationStrategy` | `Random` (default) or `SequentialVersion7` |
+| `UnsupportedIdentifierTypeException` | Thrown when auto-generating unsupported `TId` |
+| `GetCollectionOptions<TDocument>.WithGuidIdGeneration` | Per-collection Guid generation |
+| `IMongoDocumentBindingBuilder<TDocument>.WithGuidIdGeneration` | Per-binding Guid generation |
+| `DocumentEntityExtensions` | Policy-aware no-ops; `NewId` accepts optional Guid strategy |
+
+Machine-readable baselines live under `src/Dilcore.MongoDB.Abstractions/PublicAPI.*.txt` and `src/Dilcore.MongoDB/PublicAPI.*.txt`.

--- a/samples/MongoDb.WebApi.Sample/Program.cs
+++ b/samples/MongoDb.WebApi.Sample/Program.cs
@@ -1,4 +1,5 @@
 using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using Dilcore.MongoDB.Extensions;
 using Dilcore.MongoDB.Repositories;
@@ -21,9 +22,15 @@ builder.Services.AddMongoDb(mongo => mongo
     .AddDatabase("SampleDB", db =>
     {
         db.OnCluster("primary");
+        // Fully composed document: concurrency + soft delete + audit timestamps.
         db.AddDocumentBinding<WeatherForecast>("weather", d => d
             .WithCollectionName("weatherForecasts")
-            .WithBulkRepository());
+            .WithSoftDelete()
+            .WithBulkRepository()
+            .WithGuidIdGeneration(GuidIdGenerationStrategy.SequentialVersion7));
+        // Minimal document: identifier only.
+        db.AddDocumentBinding<Note>("notes", d => d
+            .WithCollectionName("notes"));
     }));
 
 var app = builder.Build();
@@ -90,9 +97,24 @@ app.MapPost("/weather-forecasts", async (IGenericRepository<WeatherForecast> gen
     })
     .WithName("CreateWeatherForecast");
 
+app.MapGet("/notes", async (IGenericRepository<Note> notes) =>
+    {
+        var result = await notes.GetListAsync();
+        return result.IsSuccess ? Results.Ok(result.ValueOrDefault) : Results.BadRequest(result.Errors);
+    })
+    .WithName("GetNotes");
+
+app.MapPost("/notes", async (IGenericRepository<Note> notes, Note note) =>
+    {
+        var result = await notes.StoreAsync(note);
+        return result.IsSuccess ? Results.Ok(result.ValueOrDefault) : Results.BadRequest(result.Errors);
+    })
+    .WithName("CreateNote");
+
 app.Run();
 
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary) : IDocumentEntity
+record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+    : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
 {
     public Guid Id { get; set; }
     public long ETag { get; set; }
@@ -101,4 +123,10 @@ record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary) : IDocu
     public DateTime UpdatedAt { get; set; }
 
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}
+
+/// <summary>Minimal document: identifier only, no optional policies.</summary>
+record Note(string Text) : IDocumentEntity<Guid>
+{
+    public Guid Id { get; set; }
 }

--- a/src/Dilcore.MongoDB.Abstractions/Dilcore.MongoDB.Abstractions.csproj
+++ b/src/Dilcore.MongoDB.Abstractions/Dilcore.MongoDB.Abstractions.csproj
@@ -16,4 +16,12 @@
       <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
     </ItemGroup>
 
+    <ItemGroup>
+      <InternalsVisibleTo Include="Dilcore.MongoDB" />
+      <InternalsVisibleTo Include="Dilcore.MongoDB.UnitTests" />
+      <InternalsVisibleTo Include="Dilcore.MongoDB.IntegrationTests" />
+      <InternalsVisibleTo Include="Dilcore.MongoDB.Repositories.IntegrationTests" />
+      <InternalsVisibleTo Include="Dilcore.MongoDB.ArchitectureTests" />
+    </ItemGroup>
+
 </Project>

--- a/src/Dilcore.MongoDB.Abstractions/Exceptions/UnsupportedIdentifierTypeException.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Exceptions/UnsupportedIdentifierTypeException.cs
@@ -1,0 +1,18 @@
+namespace Dilcore.MongoDB.Abstractions.Exceptions;
+
+/// <summary>
+/// Thrown when auto-generating an identifier for a <see cref="IDocumentEntity{TId}"/> whose
+/// <typeparamref name="TId"/> type has no built-in generator.
+/// </summary>
+public sealed class UnsupportedIdentifierTypeException : Exception
+{
+    public UnsupportedIdentifierTypeException(Type identifierType)
+        : base(
+            $"Cannot auto-generate an identifier of type '{identifierType.FullName}'. " +
+            "Assign Id before calling StoreAsync, or use Guid / ObjectId.")
+    {
+        IdentifierType = identifierType;
+    }
+
+    public Type IdentifierType { get; }
+}

--- a/src/Dilcore.MongoDB.Abstractions/Extensions/DocumentEntityExtensions.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Extensions/DocumentEntityExtensions.cs
@@ -1,5 +1,7 @@
 using Dilcore.MongoDB.Abstractions.Exceptions;
 using Dilcore.MongoDB.Abstractions.Helpers;
+using Dilcore.MongoDB.Abstractions.Internal;
+using Dilcore.MongoDB.Abstractions.Policies;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
@@ -13,30 +15,44 @@ public static class DocumentEntityExtensions
 
     public static void GenerateETag(this IDocumentEntity document)
     {
-        document.ETag = MongoDbHelper.GenerateEtag();
+        if (document is IHasConcurrencyToken concurrencyToken)
+        {
+            concurrencyToken.ETag = MongoDbHelper.GenerateEtag();
+        }
     }
 
     public static void CreatedNow(this IDocumentEntity document)
     {
-        document.CreatedAt = DateTime.UtcNow;
+        if (document is IAuditableDocument auditable)
+        {
+            auditable.CreatedAt = DateTime.UtcNow;
+        }
     }
 
     public static void UpdatedNow(this IDocumentEntity document)
     {
-        document.UpdatedAt = DateTime.UtcNow;
+        if (document is IAuditableDocument auditable)
+        {
+            auditable.UpdatedAt = DateTime.UtcNow;
+        }
     }
 
-    public static void NewId(this IDocumentEntity document)
+    public static void NewId<TDocument>(
+        this TDocument document,
+        GuidIdGenerationStrategy guidStrategy = GuidIdGenerationStrategy.Random)
+        where TDocument : class, IDocumentEntity
     {
-        document.Id = Guid.NewGuid();
+        DocumentIdAccessorCache.Get<TDocument>().EnsureNewId(document, guidStrategy);
     }
 
-    public static bool IsIdEmpty(this IDocumentEntity document)
+    public static bool IsIdEmpty<TDocument>(this TDocument document)
+        where TDocument : class, IDocumentEntity
     {
-        return document.Id.Equals(Guid.Empty);
+        return DocumentIdAccessorCache.Get<TDocument>().IsEmpty(document);
     }
 
-    public static void CheckId(this IDocumentEntity document)
+    public static void CheckId<TDocument>(this TDocument document)
+        where TDocument : class, IDocumentEntity
     {
         if (document.IsIdEmpty())
         {
@@ -46,7 +62,13 @@ public static class DocumentEntityExtensions
 
     public static bool IsNew(this IDocumentEntity document)
     {
-        return document.ETag.Equals(Constants.EmptyETag);
+        if (document is IHasConcurrencyToken concurrencyToken)
+        {
+            return concurrencyToken.ETag.Equals(Constants.EmptyETag);
+        }
+
+        // No concurrency token: create-vs-update is decided by whether Id is empty.
+        return true;
     }
 
     public static BsonDocument ToBsonUpdateDocument<T>(this T document)

--- a/src/Dilcore.MongoDB.Abstractions/GuidIdGenerationStrategy.cs
+++ b/src/Dilcore.MongoDB.Abstractions/GuidIdGenerationStrategy.cs
@@ -1,0 +1,17 @@
+namespace Dilcore.MongoDB.Abstractions;
+
+/// <summary>
+/// Strategy used when auto-generating <see cref="Guid"/> document identifiers.
+/// </summary>
+public enum GuidIdGenerationStrategy
+{
+    /// <summary>
+    /// Random UUID version 4 via <see cref="Guid.NewGuid"/>.
+    /// </summary>
+    Random = 0,
+
+    /// <summary>
+    /// Time-ordered UUID version 7 (RFC 9562) via <see cref="Guid.CreateVersion7()"/>.
+    /// </summary>
+    SequentialVersion7 = 1
+}

--- a/src/Dilcore.MongoDB.Abstractions/IDocumentEntity.cs
+++ b/src/Dilcore.MongoDB.Abstractions/IDocumentEntity.cs
@@ -1,10 +1,16 @@
 namespace Dilcore.MongoDB.Abstractions;
 
-public interface IDocumentEntity
+/// <summary>
+/// Marker interface for documents managed by Dilcore.MongoDB repositories.
+/// Prefer <see cref="IDocumentEntity{TId}"/> to declare the identifier type.
+/// </summary>
+public interface IDocumentEntity;
+
+/// <summary>
+/// Document with a typed identifier that maps to MongoDB <c>_id</c>.
+/// </summary>
+/// <typeparam name="TId">Identifier type (e.g. <see cref="Guid"/>, <see cref="MongoDB.Bson.ObjectId"/>, <see cref="string"/>).</typeparam>
+public interface IDocumentEntity<TId> : IDocumentEntity
 {
-    Guid Id { get; set; }
-    long ETag { get; set; }
-    bool IsDeleted { get; set; }
-    DateTime CreatedAt { get; set; }
-    DateTime UpdatedAt { get; set; }
+    TId Id { get; set; }
 }

--- a/src/Dilcore.MongoDB.Abstractions/Internal/DocumentIdAccessor.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Internal/DocumentIdAccessor.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Dilcore.MongoDB.Abstractions.Exceptions;
@@ -36,16 +37,16 @@ internal static class DocumentIdAccessorCache
     {
         ArgumentNullException.ThrowIfNull(documentType);
 
-        foreach (var iface in documentType.GetInterfaces())
+        var idInterface = documentType.GetInterfaces()
+            .FirstOrDefault(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IDocumentEntity<>));
+
+        if (idInterface is null)
         {
-            if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IDocumentEntity<>))
-            {
-                return iface.GetGenericArguments()[0];
-            }
+            throw new InvalidOperationException(
+                $"Type '{documentType.FullName}' must implement IDocumentEntity<TId>.");
         }
 
-        throw new InvalidOperationException(
-            $"Type '{documentType.FullName}' must implement IDocumentEntity<TId>.");
+        return idInterface.GetGenericArguments()[0];
     }
 
     private static class Holder<TDocument>

--- a/src/Dilcore.MongoDB.Abstractions/Internal/DocumentIdAccessor.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Internal/DocumentIdAccessor.cs
@@ -1,0 +1,210 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Dilcore.MongoDB.Abstractions.Exceptions;
+using Dilcore.MongoDB.Abstractions.Policies;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Abstractions.Internal;
+
+internal interface IDocumentIdAccessor<TDocument>
+    where TDocument : class, IDocumentEntity
+{
+    Type IdentifierType { get; }
+
+    bool IsGuidIdentifier { get; }
+
+    bool IsEmpty(TDocument document);
+
+    void EnsureNewId(TDocument document, GuidIdGenerationStrategy guidStrategy = GuidIdGenerationStrategy.Random);
+
+    FilterDefinition<TDocument> BuildIdFilter(TDocument document);
+}
+
+internal static class DocumentIdAccessorCache
+{
+    private static readonly MethodInfo CreateCoreMethod =
+        typeof(DocumentIdAccessorCache).GetMethod(
+            nameof(CreateCore),
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    public static IDocumentIdAccessor<TDocument> Get<TDocument>()
+        where TDocument : class, IDocumentEntity
+        => Holder<TDocument>.Instance;
+
+    public static Type ResolveIdentifierType(Type documentType)
+    {
+        ArgumentNullException.ThrowIfNull(documentType);
+
+        foreach (var iface in documentType.GetInterfaces())
+        {
+            if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IDocumentEntity<>))
+            {
+                return iface.GetGenericArguments()[0];
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Type '{documentType.FullName}' must implement IDocumentEntity<TId>.");
+    }
+
+    private static class Holder<TDocument>
+        where TDocument : class, IDocumentEntity
+    {
+        public static readonly IDocumentIdAccessor<TDocument> Instance = Create<TDocument>();
+    }
+
+    private static IDocumentIdAccessor<TDocument> Create<TDocument>()
+        where TDocument : class, IDocumentEntity
+    {
+        var idType = ResolveIdentifierType(typeof(TDocument));
+        var factory = CreateCoreMethod.MakeGenericMethod(typeof(TDocument), idType);
+        return (IDocumentIdAccessor<TDocument>)factory.Invoke(null, null)!;
+    }
+
+    private static IDocumentIdAccessor<TDocument> CreateCore<TDocument, TId>()
+        where TDocument : class, IDocumentEntity
+        => new DocumentIdAccessor<TDocument, TId>();
+}
+
+internal sealed class DocumentIdAccessor<TDocument, TId> : IDocumentIdAccessor<TDocument>
+    where TDocument : class, IDocumentEntity
+{
+    private static readonly Func<TDocument, TId> GetId = CompileGetter();
+    private static readonly Action<TDocument, TId> SetId = CompileSetter();
+    private static readonly Func<TId, bool> IsEmptyValue = CompileIsEmpty();
+    private static readonly Func<GuidIdGenerationStrategy, TId>? GenerateId = CompileGenerator();
+    private static readonly Expression<Func<TDocument, TId>> IdExpression = CompileIdExpression();
+
+    public Type IdentifierType => typeof(TId);
+
+    public bool IsGuidIdentifier { get; } = typeof(TId) == typeof(Guid);
+
+    public bool IsEmpty(TDocument document) => IsEmptyValue(GetId(document));
+
+    public void EnsureNewId(TDocument document, GuidIdGenerationStrategy guidStrategy = GuidIdGenerationStrategy.Random)
+    {
+        if (!IsEmpty(document))
+        {
+            return;
+        }
+
+        if (GenerateId is null)
+        {
+            throw new UnsupportedIdentifierTypeException(typeof(TId));
+        }
+
+        SetId(document, GenerateId(guidStrategy));
+    }
+
+    public FilterDefinition<TDocument> BuildIdFilter(TDocument document)
+        => Builders<TDocument>.Filter.Eq(IdExpression, GetId(document));
+
+    private static Expression<Func<TDocument, TId>> CompileIdExpression()
+    {
+        var document = Expression.Parameter(typeof(TDocument), "document");
+        var body = Expression.Property(
+            Expression.Convert(document, typeof(IDocumentEntity<TId>)),
+            nameof(IDocumentEntity<TId>.Id));
+        return Expression.Lambda<Func<TDocument, TId>>(body, document);
+    }
+
+    private static Func<TDocument, TId> CompileGetter() => CompileIdExpression().Compile();
+
+    private static Action<TDocument, TId> CompileSetter()
+    {
+        var document = Expression.Parameter(typeof(TDocument), "document");
+        var value = Expression.Parameter(typeof(TId), "value");
+        var property = Expression.Property(
+            Expression.Convert(document, typeof(IDocumentEntity<TId>)),
+            nameof(IDocumentEntity<TId>.Id));
+        var body = Expression.Assign(property, value);
+        return Expression.Lambda<Action<TDocument, TId>>(body, document, value).Compile();
+    }
+
+    private static Func<TId, bool> CompileIsEmpty()
+    {
+        var id = Expression.Parameter(typeof(TId), "id");
+
+        Expression body;
+        if (typeof(TId) == typeof(string))
+        {
+            body = Expression.Call(
+                typeof(string).GetMethod(nameof(string.IsNullOrEmpty), [typeof(string)])!,
+                Expression.Convert(id, typeof(string)));
+        }
+        else
+        {
+            Expression empty;
+            if (typeof(TId) == typeof(Guid))
+            {
+                empty = Expression.Constant(Guid.Empty, typeof(TId));
+            }
+            else if (typeof(TId) == typeof(ObjectId))
+            {
+                empty = Expression.Constant(ObjectId.Empty, typeof(TId));
+            }
+            else
+            {
+                empty = Expression.Default(typeof(TId));
+            }
+
+            body = Expression.Equal(id, empty);
+        }
+
+        return Expression.Lambda<Func<TId, bool>>(body, id).Compile();
+    }
+
+    private static Func<GuidIdGenerationStrategy, TId>? CompileGenerator()
+    {
+        if (typeof(TId) == typeof(Guid))
+        {
+            return strategy =>
+            {
+                var guid = strategy switch
+                {
+                    GuidIdGenerationStrategy.Random => Guid.NewGuid(),
+                    GuidIdGenerationStrategy.SequentialVersion7 => Guid.CreateVersion7(),
+                    _ => throw new ArgumentOutOfRangeException(nameof(strategy), strategy, null)
+                };
+                return (TId)(object)guid;
+            };
+        }
+
+        if (typeof(TId) == typeof(ObjectId))
+        {
+            return _ => (TId)(object)ObjectId.GenerateNewId();
+        }
+
+        return null;
+    }
+}
+
+internal static class SoftDeleteFilterCache
+{
+    public static FilterDefinition<TDocument> GetNotDeletedFilter<TDocument>()
+        where TDocument : class, IDocumentEntity
+        => SoftDeleteHolder<TDocument>.Filter;
+
+    private static class SoftDeleteHolder<TDocument>
+        where TDocument : class, IDocumentEntity
+    {
+        public static readonly FilterDefinition<TDocument> Filter = Create();
+
+        private static FilterDefinition<TDocument> Create()
+        {
+            if (!typeof(ISoftDeletable).IsAssignableFrom(typeof(TDocument)))
+            {
+                return Builders<TDocument>.Filter.Empty;
+            }
+
+            var document = Expression.Parameter(typeof(TDocument), "document");
+            var isDeleted = Expression.Property(
+                Expression.Convert(document, typeof(ISoftDeletable)),
+                nameof(ISoftDeletable.IsDeleted));
+            var body = Expression.Equal(isDeleted, Expression.Constant(false));
+            var predicate = Expression.Lambda<Func<TDocument, bool>>(body, document);
+            return Builders<TDocument>.Filter.Where(predicate);
+        }
+    }
+}

--- a/src/Dilcore.MongoDB.Abstractions/Options/GetCollectionOptions.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Options/GetCollectionOptions.cs
@@ -14,6 +14,9 @@ public class GetCollectionOptions<TDocument>
     public bool SoftDeleteEnabled { get; private set; }
     public bool SoftDeleteDisabled => !SoftDeleteEnabled;
 
+    public GuidIdGenerationStrategy GuidIdGenerationStrategy { get; private set; } =
+        GuidIdGenerationStrategy.Random;
+
     public GetCollectionOptions<TDocument> WithCollectionName(string collectionName)
     {
         CollectionName = collectionName;
@@ -44,6 +47,12 @@ public class GetCollectionOptions<TDocument>
     public GetCollectionOptions<TDocument> WithSoftDelete()
     {
         SoftDeleteEnabled = true;
+        return this;
+    }
+
+    public GetCollectionOptions<TDocument> WithGuidIdGeneration(GuidIdGenerationStrategy strategy)
+    {
+        GuidIdGenerationStrategy = strategy;
         return this;
     }
 }

--- a/src/Dilcore.MongoDB.Abstractions/Policies/IAuditableDocument.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Policies/IAuditableDocument.cs
@@ -1,0 +1,10 @@
+namespace Dilcore.MongoDB.Abstractions.Policies;
+
+/// <summary>
+/// Opt-in create/update audit timestamps for a document.
+/// </summary>
+public interface IAuditableDocument
+{
+    DateTime CreatedAt { get; set; }
+    DateTime UpdatedAt { get; set; }
+}

--- a/src/Dilcore.MongoDB.Abstractions/Policies/IHasConcurrencyToken.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Policies/IHasConcurrencyToken.cs
@@ -1,0 +1,9 @@
+namespace Dilcore.MongoDB.Abstractions.Policies;
+
+/// <summary>
+/// Opt-in optimistic concurrency token (ETag) for a document.
+/// </summary>
+public interface IHasConcurrencyToken
+{
+    long ETag { get; set; }
+}

--- a/src/Dilcore.MongoDB.Abstractions/Policies/ISoftDeletable.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Policies/ISoftDeletable.cs
@@ -1,0 +1,9 @@
+namespace Dilcore.MongoDB.Abstractions.Policies;
+
+/// <summary>
+/// Opt-in soft-delete flag for a document.
+/// </summary>
+public interface ISoftDeletable
+{
+    bool IsDeleted { get; set; }
+}

--- a/src/Dilcore.MongoDB.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Dilcore.MongoDB.Abstractions/PublicAPI.Shipped.txt
@@ -1,9 +1,12 @@
 #nullable enable
 static class Dilcore.MongoDB.Abstractions.Constants
 class Dilcore.MongoDB.Abstractions.Exceptions.DocumentIdentifierIsEmptyException
+class Dilcore.MongoDB.Abstractions.Exceptions.UnsupportedIdentifierTypeException
 static class Dilcore.MongoDB.Abstractions.Extensions.DocumentEntityExtensions
+enum Dilcore.MongoDB.Abstractions.GuidIdGenerationStrategy
 static class Dilcore.MongoDB.Abstractions.Helpers.MongoDbHelper
 interface Dilcore.MongoDB.Abstractions.IDocumentEntity
+interface Dilcore.MongoDB.Abstractions.IDocumentEntity`1
 interface Dilcore.MongoDB.Abstractions.IMongoDatabaseResolver
 interface Dilcore.MongoDB.Abstractions.IMongoDbCollectionFactory
 struct Dilcore.MongoDB.Abstractions.Keys.MongoClusterKey
@@ -16,6 +19,9 @@ class Dilcore.MongoDB.Abstractions.Namespace.NamespaceResolutionRequest
 enum Dilcore.MongoDB.Abstractions.Namespace.NamespaceTarget
 class Dilcore.MongoDB.Abstractions.Options.GetCollectionOptions`1
 enum Dilcore.MongoDB.Abstractions.Ownership.MongoClientOwnership
+interface Dilcore.MongoDB.Abstractions.Policies.IAuditableDocument
+interface Dilcore.MongoDB.Abstractions.Policies.IHasConcurrencyToken
+interface Dilcore.MongoDB.Abstractions.Policies.ISoftDeletable
 class Dilcore.MongoDB.Abstractions.Repositories.BaseMongoDbRepository`1
 class Dilcore.MongoDB.Abstractions.Repositories.BsonDocumentRepository
 interface Dilcore.MongoDB.Abstractions.Repositories.IGenericBulkRepository`1

--- a/src/Dilcore.MongoDB.Abstractions/Repositories/BaseMongoDbRepository.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Repositories/BaseMongoDbRepository.cs
@@ -1,4 +1,6 @@
+using Dilcore.MongoDB.Abstractions.Internal;
 using Dilcore.MongoDB.Abstractions.Options;
+using Dilcore.MongoDB.Abstractions.Policies;
 using FluentResults;
 using MongoDB.Driver;
 
@@ -6,8 +8,11 @@ namespace Dilcore.MongoDB.Abstractions.Repositories;
 
 public abstract class BaseMongoDbRepository<TDocument> where TDocument : class, IDocumentEntity
 {
+    private static readonly bool IsSoftDeletable =
+        typeof(ISoftDeletable).IsAssignableFrom(typeof(TDocument));
+
     private static readonly FilterDefinition<TDocument> NotDeletedFilter =
-        Builders<TDocument>.Filter.Eq(x => x.IsDeleted, false);
+        SoftDeleteFilterCache.GetNotDeletedFilter<TDocument>();
 
     private readonly Func<CancellationToken, Task<Result<IMongoCollection<TDocument>>>> _collectionProvider;
     private readonly GetCollectionOptions<TDocument> _options;
@@ -62,23 +67,32 @@ public abstract class BaseMongoDbRepository<TDocument> where TDocument : class, 
     protected FilterDefinition<TDerived> ApplyNotDeleteFilter<TDerived>(FilterDefinition<TDerived> filter)
         where TDerived : class, TDocument
     {
-        return _options.SoftDeleteDisabled
-            ? filter
-            : filter & Builders<TDerived>.Filter.Eq(x => x.IsDeleted, false);
+        if (_options.SoftDeleteDisabled || !IsSoftDeletable)
+        {
+            return filter;
+        }
+
+        return filter & SoftDeleteFilterCache.GetNotDeletedFilter<TDerived>();
     }
 
     protected FilterDefinition<TDocument> ApplyNotDeleteFilter(FilterDefinition<TDocument> filter)
     {
-        return _options.SoftDeleteDisabled
-            ? filter
-            : filter & NotDeletedFilter;
+        if (_options.SoftDeleteDisabled || !IsSoftDeletable)
+        {
+            return filter;
+        }
+
+        return filter & NotDeletedFilter;
     }
 
     protected FilterDefinition<TDocument> ApplyNotDeleteFilter()
     {
-        return _options.SoftDeleteDisabled
-            ? Builders<TDocument>.Filter.Empty
-            : NotDeletedFilter;
+        if (_options.SoftDeleteDisabled || !IsSoftDeletable)
+        {
+            return Builders<TDocument>.Filter.Empty;
+        }
+
+        return NotDeletedFilter;
     }
 
     private Task<Result<IMongoCollection<TDocument>>> GetCollectionAsync(CancellationToken cancellationToken = default)

--- a/src/Dilcore.MongoDB/DependencyInjection/IMongoDocumentBindingBuilder.cs
+++ b/src/Dilcore.MongoDB/DependencyInjection/IMongoDocumentBindingBuilder.cs
@@ -12,6 +12,8 @@ public interface IMongoDocumentBindingBuilder<TDocument>
 
     IMongoDocumentBindingBuilder<TDocument> WithSoftDelete();
 
+    IMongoDocumentBindingBuilder<TDocument> WithGuidIdGeneration(GuidIdGenerationStrategy strategy);
+
     IMongoDocumentBindingBuilder<TDocument> WithBulkRepository();
 
     IMongoDocumentBindingBuilder<TDocument> WithProjectionRepository();

--- a/src/Dilcore.MongoDB/DependencyInjection/MongoDocumentBindingBuilder.cs
+++ b/src/Dilcore.MongoDB/DependencyInjection/MongoDocumentBindingBuilder.cs
@@ -1,7 +1,9 @@
 using System.Linq.Expressions;
 using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Internal;
 using Dilcore.MongoDB.Abstractions.Keys;
 using Dilcore.MongoDB.Abstractions.Namespace;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Descriptors;
 using MongoDB.Driver;
 
@@ -19,6 +21,8 @@ internal sealed class MongoDocumentBindingBuilder<TDocument> : IMongoDocumentBin
     private IReadOnlyList<CreateIndexModel<TDocument>>? _indices;
     private TimeSpan? _ttl;
     private Expression<Func<TDocument, object>>? _ttlSelector;
+    private GuidIdGenerationStrategy _guidIdGenerationStrategy = GuidIdGenerationStrategy.Random;
+    private bool _guidIdGenerationConfigured;
 
     public IMongoDocumentBindingBuilder<TDocument> WithCollectionName(string collectionName)
     {
@@ -29,7 +33,28 @@ internal sealed class MongoDocumentBindingBuilder<TDocument> : IMongoDocumentBin
 
     public IMongoDocumentBindingBuilder<TDocument> WithSoftDelete()
     {
+        if (!typeof(ISoftDeletable).IsAssignableFrom(typeof(TDocument)))
+        {
+            throw new InvalidOperationException(
+                $"WithSoftDelete requires '{typeof(TDocument).Name}' to implement {nameof(ISoftDeletable)}.");
+        }
+
         _softDeleteEnabled = true;
+        return this;
+    }
+
+    public IMongoDocumentBindingBuilder<TDocument> WithGuidIdGeneration(GuidIdGenerationStrategy strategy)
+    {
+        var identifierType = DocumentIdAccessorCache.ResolveIdentifierType(typeof(TDocument));
+        if (identifierType != typeof(Guid))
+        {
+            throw new InvalidOperationException(
+                $"WithGuidIdGeneration requires '{typeof(TDocument).Name}' to implement IDocumentEntity<Guid>, " +
+                $"but its identifier type is '{identifierType.Name}'.");
+        }
+
+        _guidIdGenerationStrategy = strategy;
+        _guidIdGenerationConfigured = true;
         return this;
     }
 
@@ -90,6 +115,9 @@ internal sealed class MongoDocumentBindingBuilder<TDocument> : IMongoDocumentBin
                 $"Document binding '{name}' must call WithCollectionName(\"<collection-name>\").");
         }
 
+        // Ensure the document declares IDocumentEntity<TId> (throws if missing).
+        _ = DocumentIdAccessorCache.ResolveIdentifierType(typeof(TDocument));
+
         return new DocumentBindingDescriptor(
             new MongoDocumentBindingKey(name),
             typeof(TDocument),
@@ -102,6 +130,7 @@ internal sealed class MongoDocumentBindingBuilder<TDocument> : IMongoDocumentBin
             _indices?.Cast<object>().ToList(),
             _ttl,
             _ttlSelector,
-            _namespacePrefixResolverType);
+            _namespacePrefixResolverType,
+            _guidIdGenerationConfigured ? _guidIdGenerationStrategy : GuidIdGenerationStrategy.Random);
     }
 }

--- a/src/Dilcore.MongoDB/Descriptors/DocumentBindingDescriptor.cs
+++ b/src/Dilcore.MongoDB/Descriptors/DocumentBindingDescriptor.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using Dilcore.MongoDB.Abstractions;
 using Dilcore.MongoDB.Abstractions.Keys;
 
 namespace Dilcore.MongoDB.Descriptors;
@@ -15,4 +16,5 @@ internal sealed record DocumentBindingDescriptor(
     IReadOnlyList<object>? Indices,
     TimeSpan? CollectionItemsTimeToLive,
     LambdaExpression? TimeToLeavePropertySelector,
-    Type? NamespacePrefixResolverType = null);
+    Type? NamespacePrefixResolverType = null,
+    GuidIdGenerationStrategy GuidIdGenerationStrategy = GuidIdGenerationStrategy.Random);

--- a/src/Dilcore.MongoDB/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Dilcore.MongoDB/Extensions/ServiceCollectionExtensions.cs
@@ -133,6 +133,8 @@ public static class ServiceCollectionExtensions
                 options.WithSoftDelete();
             }
 
+            options.WithGuidIdGeneration(binding.GuidIdGenerationStrategy);
+
             if (binding.Indices is { Count: > 0 })
             {
                 options.WithIndexes(binding.Indices.Cast<CreateIndexModel<TDocument>>().ToArray());
@@ -192,6 +194,8 @@ public static class ServiceCollectionExtensions
             {
                 options.WithSoftDelete();
             }
+
+            options.WithGuidIdGeneration(binding.GuidIdGenerationStrategy);
         };
 
         services.AddScoped<IGenericRepository<TDocument>>(sp =>

--- a/src/Dilcore.MongoDB/Internal/MongoDbCollectionFactory.cs
+++ b/src/Dilcore.MongoDB/Internal/MongoDbCollectionFactory.cs
@@ -67,6 +67,8 @@ internal sealed class MongoDbCollectionFactory(
             options.WithSoftDelete();
         }
 
+        options.WithGuidIdGeneration(binding.GuidIdGenerationStrategy);
+
         if (binding.Indices is { Count: > 0 })
         {
             options.WithIndexes(binding.Indices.Cast<CreateIndexModel<TDocument>>().ToArray());

--- a/src/Dilcore.MongoDB/Repositories/GenericMongoDbBulkRepository.cs
+++ b/src/Dilcore.MongoDB/Repositories/GenericMongoDbBulkRepository.cs
@@ -2,7 +2,9 @@ using System.Linq.Expressions;
 using Dilcore.MongoDB.Abstractions;
 using Dilcore.MongoDB.Abstractions.Extensions;
 using Dilcore.MongoDB.Abstractions.Helpers;
+using Dilcore.MongoDB.Abstractions.Internal;
 using Dilcore.MongoDB.Abstractions.Options;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using FluentResults;
 using MongoDB.Driver;
@@ -15,6 +17,15 @@ internal class GenericMongoDbBulkRepository<TDocument>(
     : BaseMongoDbRepository<TDocument>(options, collectionProvider), IGenericBulkRepository<TDocument>
     where TDocument : class, IDocumentEntity
 {
+    private static readonly bool HasConcurrencyToken =
+        typeof(IHasConcurrencyToken).IsAssignableFrom(typeof(TDocument));
+
+    private static readonly bool IsSoftDeletable =
+        typeof(ISoftDeletable).IsAssignableFrom(typeof(TDocument));
+
+    private static readonly IDocumentIdAccessor<TDocument> IdAccessor =
+        DocumentIdAccessorCache.Get<TDocument>();
+
     public Task<Result<IReadOnlyList<TDocument>>> BulkStoreAsync(
         TDocument[] entities,
         CancellationToken cancellationToken = default)
@@ -33,7 +44,7 @@ internal class GenericMongoDbBulkRepository<TDocument>(
                 return Result.Fail("Not all entities were created");
             }
 
-            if (result.ModifiedCount != writeModels.Count(x => x.ModelType == WriteModelType.UpdateOne))
+            if (result.ModifiedCount != writeModels.Count(x => x.ModelType == WriteModelType.UpdateOne || x.ModelType == WriteModelType.ReplaceOne))
             {
                 return Result.Fail("Not all entities were updated");
             }
@@ -66,7 +77,7 @@ internal class GenericMongoDbBulkRepository<TDocument>(
                 return Result.Fail("Not all entities were created");
             }
 
-            if (result.ModifiedCount != writeModels.Count(x => x.ModelType == WriteModelType.UpdateOne))
+            if (result.ModifiedCount != writeModels.Count(x => x.ModelType == WriteModelType.UpdateOne || x.ModelType == WriteModelType.ReplaceOne))
             {
                 return Result.Fail("Not all entities were updated");
             }
@@ -82,7 +93,7 @@ internal class GenericMongoDbBulkRepository<TDocument>(
             var collectionOptions = GetOptions();
             var filter = Builders<TDocument>.Filter.Where(expression);
 
-            if (collectionOptions.SoftDeleteDisabled)
+            if (collectionOptions.SoftDeleteDisabled || !IsSoftDeletable)
             {
                 return PermanentDeleteAsync(collection, filter, token);
             }
@@ -96,8 +107,11 @@ internal class GenericMongoDbBulkRepository<TDocument>(
         FilterDefinition<TDocument> filter,
         CancellationToken token)
     {
-        var update = Builders<TDocument>.Update.Set(x => x.IsDeleted, true)
-            .Set(x => x.ETag, MongoDbHelper.GenerateEtag());
+        UpdateDefinition<TDocument> update = Builders<TDocument>.Update.Set("isDeleted", true);
+        if (HasConcurrencyToken)
+        {
+            update = update.Set("eTag", MongoDbHelper.GenerateEtag());
+        }
 
         var result = await collection.UpdateManyAsync(filter, update, cancellationToken: token);
         return result.MatchedCount == 0 ? Result.Fail("No entities were deleted") : Result.Ok();
@@ -114,13 +128,19 @@ internal class GenericMongoDbBulkRepository<TDocument>(
 
     private IEnumerable<WriteModel<TDocument>> CreateWriteModels(IEnumerable<TDocument> entities)
     {
+        var guidStrategy = GetOptions().GuidIdGenerationStrategy;
+
         foreach (var entity in entities)
         {
-            if (entity.IsNew())
+            var isCreate = HasConcurrencyToken
+                ? entity.IsNew()
+                : IdAccessor.IsEmpty(entity);
+
+            if (isCreate)
             {
-                if (entity.IsIdEmpty())
+                if (IdAccessor.IsEmpty(entity))
                 {
-                    entity.NewId();
+                    IdAccessor.EnsureNewId(entity, guidStrategy);
                 }
 
                 entity.GenerateETag();
@@ -131,16 +151,26 @@ internal class GenericMongoDbBulkRepository<TDocument>(
                 continue;
             }
 
-            var currentETag = entity.ETag;
-            entity.GenerateETag();
             entity.UpdatedNow();
 
-            var filter = Builders<TDocument>.Filter.Eq(x => x.Id, entity.Id);
-            filter &= Builders<TDocument>.Filter.Eq(x => x.ETag, currentETag);
-            filter = ApplyNotDeleteFilter(filter);
+            if (HasConcurrencyToken)
+            {
+                var currentETag = ((IHasConcurrencyToken)entity).ETag;
+                entity.GenerateETag();
 
-            var updateDocument = entity.ToBsonUpdateDocument();
-            yield return new UpdateOneModel<TDocument>(filter, updateDocument);
+                var filter = IdAccessor.BuildIdFilter(entity);
+                filter &= Builders<TDocument>.Filter.Eq("eTag", currentETag);
+                filter = ApplyNotDeleteFilter(filter);
+
+                var updateDocument = entity.ToBsonUpdateDocument();
+                yield return new UpdateOneModel<TDocument>(filter, updateDocument);
+            }
+            else
+            {
+                entity.GenerateETag();
+                var filter = ApplyNotDeleteFilter(IdAccessor.BuildIdFilter(entity));
+                yield return new ReplaceOneModel<TDocument>(filter, entity);
+            }
         }
     }
 }

--- a/src/Dilcore.MongoDB/Repositories/GenericMongoDbRepository.cs
+++ b/src/Dilcore.MongoDB/Repositories/GenericMongoDbRepository.cs
@@ -1,7 +1,9 @@
 using Dilcore.MongoDB.Abstractions;
 using Dilcore.MongoDB.Abstractions.Extensions;
 using Dilcore.MongoDB.Abstractions.Helpers;
+using Dilcore.MongoDB.Abstractions.Internal;
 using Dilcore.MongoDB.Abstractions.Options;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using FluentResults;
 using MongoDB.Driver;
@@ -14,6 +16,15 @@ internal class GenericMongoDbRepository<TDocument>(
     : BaseMongoDbRepository<TDocument>(options, collectionProvider), IGenericRepository<TDocument>
     where TDocument : class, IDocumentEntity
 {
+    private static readonly bool HasConcurrencyToken =
+        typeof(IHasConcurrencyToken).IsAssignableFrom(typeof(TDocument));
+
+    private static readonly bool IsSoftDeletable =
+        typeof(ISoftDeletable).IsAssignableFrom(typeof(TDocument));
+
+    private static readonly IDocumentIdAccessor<TDocument> IdAccessor =
+        DocumentIdAccessorCache.Get<TDocument>();
+
     public Task<Result<TDocument>> StoreAsync(TDocument entity, CancellationToken cancellationToken = default)
         => ExecuteAsync((collection, ct) => StoreEntityAsync(entity, collection, ct), cancellationToken);
 
@@ -116,7 +127,7 @@ internal class GenericMongoDbRepository<TDocument>(
         {
             var collectionOptions = GetOptions();
 
-            if (collectionOptions.SoftDeleteDisabled)
+            if (collectionOptions.SoftDeleteDisabled || !IsSoftDeletable)
             {
                 return PermanentDeleteOneAsync(collection, filter, token);
             }
@@ -144,22 +155,29 @@ internal class GenericMongoDbRepository<TDocument>(
         IMongoCollection<TDocument> collection,
         CancellationToken cancellationToken = default)
     {
-        var currentEtag = entity.ETag;
         entity.UpdatedNow();
 
-        return entity.IsNew()
+        if (HasConcurrencyToken)
+        {
+            var currentEtag = ((IHasConcurrencyToken)entity).ETag;
+            return entity.IsNew()
+                ? CreateAsync(entity, collection, cancellationToken)
+                : UpdateWithConcurrencyAsync(entity, currentEtag, collection, cancellationToken);
+        }
+
+        return IdAccessor.IsEmpty(entity)
             ? CreateAsync(entity, collection, cancellationToken)
-            : UpdateAsync(entity, currentEtag, collection, cancellationToken);
+            : ReplaceWithoutConcurrencyAsync(entity, collection, cancellationToken);
     }
 
-    private static async Task<Result<TDocument>> CreateAsync(
+    private async Task<Result<TDocument>> CreateAsync(
         TDocument entity,
         IMongoCollection<TDocument> collection,
         CancellationToken cancellationToken)
     {
-        if (entity.IsIdEmpty())
+        if (IdAccessor.IsEmpty(entity))
         {
-            entity.NewId();
+            IdAccessor.EnsureNewId(entity, GetOptions().GuidIdGenerationStrategy);
         }
 
         entity.CreatedNow();
@@ -169,14 +187,14 @@ internal class GenericMongoDbRepository<TDocument>(
         return Result.Ok(entity);
     }
 
-    private async Task<Result<TDocument>> UpdateAsync(
+    private async Task<Result<TDocument>> UpdateWithConcurrencyAsync(
         TDocument entity,
         long currentEtag,
         IMongoCollection<TDocument> collection,
         CancellationToken cancellationToken)
     {
-        var filter = Builders<TDocument>.Filter.Eq(x => x.Id, entity.Id);
-        filter &= Builders<TDocument>.Filter.Eq(x => x.ETag, currentEtag);
+        var filter = IdAccessor.BuildIdFilter(entity);
+        filter &= Builders<TDocument>.Filter.Eq("eTag", currentEtag);
         filter = ApplyNotDeleteFilter(filter);
 
         entity.GenerateETag();
@@ -187,7 +205,23 @@ internal class GenericMongoDbRepository<TDocument>(
 
         return updateResult.ModifiedCount == 1
             ? Result.Ok(entity)
-            : Result.Fail($"Failed to update entity '{collection.CollectionNamespace}' with id {entity.Id}");
+            : Result.Fail($"Failed to update entity '{collection.CollectionNamespace}' with id filter");
+    }
+
+    private async Task<Result<TDocument>> ReplaceWithoutConcurrencyAsync(
+        TDocument entity,
+        IMongoCollection<TDocument> collection,
+        CancellationToken cancellationToken)
+    {
+        var filter = IdAccessor.BuildIdFilter(entity);
+        filter = ApplyNotDeleteFilter(filter);
+
+        entity.GenerateETag();
+        var result = await collection.ReplaceOneAsync(filter, entity, cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1 || result.MatchedCount == 1
+            ? Result.Ok(entity)
+            : Result.Fail($"Failed to update entity '{collection.CollectionNamespace}' with id filter");
     }
 
     private static async Task<Result<bool>> SoftDeleteOneAsync(
@@ -195,8 +229,11 @@ internal class GenericMongoDbRepository<TDocument>(
         FilterDefinition<TDocument> filter,
         CancellationToken cancellationToken = default)
     {
-        var update = Builders<TDocument>.Update.Set(x => x.IsDeleted, true)
-            .Set(x => x.ETag, MongoDbHelper.GenerateEtag());
+        UpdateDefinition<TDocument> update = Builders<TDocument>.Update.Set("isDeleted", true);
+        if (HasConcurrencyToken)
+        {
+            update = update.Set("eTag", MongoDbHelper.GenerateEtag());
+        }
 
         var result = await collection.UpdateOneAsync(filter, update, cancellationToken: cancellationToken);
         return Result.Ok(result.ModifiedCount == 1);

--- a/src/Dilcore.MongoDB/Repositories/GenericRepositoryExtensions.cs
+++ b/src/Dilcore.MongoDB/Repositories/GenericRepositoryExtensions.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using FluentResults;
 using MongoDB.Driver;
@@ -8,46 +9,49 @@ namespace Dilcore.MongoDB.Repositories;
 
 public static class GenericRepositoryExtensions
 {
+    public static Task<Result<TDocument>> GetAsync<TDocument, TId>(
+        this IGenericRepository<TDocument> repository,
+        TId id,
+        CancellationToken cancellationToken = default)
+        where TDocument : class, IDocumentEntity<TId>
+        => repository.GetAsync(IdEquals<TDocument, TId>(id), cancellationToken);
+
     public static Task<Result<TDocument>> GetAsync<TDocument>(
         this IGenericRepository<TDocument> repository,
         Guid id,
         CancellationToken cancellationToken = default)
-        where TDocument : class, IDocumentEntity
-    {
-        var filter = Builders<TDocument>.Filter.Eq(x => x.Id, id);
-        return repository.GetAsync(filter, cancellationToken);
-    }
+        where TDocument : class, IDocumentEntity<Guid>
+        => repository.GetAsync<TDocument, Guid>(id, cancellationToken);
+
+    public static Task<Result<TDerived>> GetAsync<TDocument, TDerived, TId>(
+        this IGenericRepository<TDocument> repository,
+        TId id,
+        CancellationToken cancellationToken = default)
+        where TDocument : class, IDocumentEntity<TId>
+        where TDerived : class, TDocument
+        => repository.GetAsync(IdEquals<TDerived, TId>(id), cancellationToken);
 
     public static Task<Result<TDerived>> GetAsync<TDocument, TDerived>(
         this IGenericRepository<TDocument> repository,
         Guid id,
         CancellationToken cancellationToken = default)
-        where TDocument : class, IDocumentEntity
+        where TDocument : class, IDocumentEntity<Guid>
         where TDerived : class, TDocument
-    {
-        var filter = Builders<TDerived>.Filter.Eq(x => x.Id, id);
-        return repository.GetAsync(filter, cancellationToken);
-    }
+        => repository.GetAsync<TDocument, TDerived, Guid>(id, cancellationToken);
 
     public static Task<Result<TDocument>> GetAsync<TDocument>(
         this IGenericRepository<TDocument> repository,
         Expression<Func<TDocument, bool>> expression,
         CancellationToken cancellationToken = default)
         where TDocument : class, IDocumentEntity
-    {
-        var filter = Builders<TDocument>.Filter.Where(expression);
-        return repository.GetAsync(filter, cancellationToken);
-    }
+        => repository.GetAsync(Builders<TDocument>.Filter.Where(expression), cancellationToken);
 
     public static Task<Result<IReadOnlyList<TDocument>>> GetListAsync<TDocument>(
         this IGenericRepository<TDocument> repository,
         Expression<Func<TDocument, bool>> expression,
         CancellationToken cancellationToken = default)
         where TDocument : class, IDocumentEntity
-    {
-        var filter = Builders<TDocument>.Filter.Where(expression);
-        return repository.GetListAsync(filter, cancellationToken);
-    }
+        => repository.GetListAsync(Builders<TDocument>.Filter.Where(expression), cancellationToken);
 
     public static Task<Result<IReadOnlyList<TDerived>>> GetListAsync<TDocument, TDerived>(
         this IGenericRepository<TDocument> repository,
@@ -55,30 +59,36 @@ public static class GenericRepositoryExtensions
         CancellationToken cancellationToken = default)
         where TDocument : class, IDocumentEntity
         where TDerived : class, TDocument
-    {
-        var filter = Builders<TDerived>.Filter.Where(expression);
-        return repository.GetListAsync(filter, cancellationToken);
-    }
+        => repository.GetListAsync(Builders<TDerived>.Filter.Where(expression), cancellationToken);
+
+    public static Task<Result<bool>> DeleteAsync<TDocument, TId>(
+        this IGenericRepository<TDocument> repository,
+        TId id,
+        long eTag,
+        CancellationToken cancellationToken = default)
+        where TDocument : class, IDocumentEntity<TId>, IHasConcurrencyToken
+        => repository.DeleteAsync(IdAndETagEquals<TDocument, TId>(id, eTag), cancellationToken);
 
     public static Task<Result<bool>> DeleteAsync<TDocument>(
         this IGenericRepository<TDocument> repository,
         Guid id,
         long eTag,
         CancellationToken cancellationToken = default)
-        where TDocument : class, IDocumentEntity
-    {
-        var filter = Builders<TDocument>.Filter.Eq(x => x.Id, id);
-        filter &= Builders<TDocument>.Filter.Eq(x => x.ETag, eTag);
-        return repository.DeleteAsync(filter, cancellationToken);
-    }
+        where TDocument : class, IDocumentEntity<Guid>, IHasConcurrencyToken
+        => repository.DeleteAsync<TDocument, Guid>(id, eTag, cancellationToken);
 
     public static Task<Result<bool>> DeleteAsync<TDocument>(
         this IGenericRepository<TDocument> repository,
         Expression<Func<TDocument, bool>> expression,
         CancellationToken cancellationToken = default)
         where TDocument : class, IDocumentEntity
-    {
-        var filter = Builders<TDocument>.Filter.Where(expression);
-        return repository.DeleteAsync(filter, cancellationToken);
-    }
+        => repository.DeleteAsync(Builders<TDocument>.Filter.Where(expression), cancellationToken);
+
+    private static FilterDefinition<TDocument> IdEquals<TDocument, TId>(TId id)
+        where TDocument : class, IDocumentEntity<TId>
+        => Builders<TDocument>.Filter.Eq(x => x.Id, id);
+
+    private static FilterDefinition<TDocument> IdAndETagEquals<TDocument, TId>(TId id, long eTag)
+        where TDocument : class, IDocumentEntity<TId>, IHasConcurrencyToken
+        => IdEquals<TDocument, TId>(id) & Builders<TDocument>.Filter.Eq(x => x.ETag, eTag);
 }

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/BenchmarkConfig.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/BenchmarkConfig.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+
+namespace Dilcore.MongoDB.Benchmarks;
+
+/// <summary>
+/// Default run shape: ≥1 warmup and ≥15 measured iterations (v2-goals protocol).
+/// </summary>
+public sealed class BenchmarkConfig : ManualConfig
+{
+    public static ManualConfig Default { get; } = new BenchmarkConfig();
+
+    public BenchmarkConfig()
+    {
+        AddLogger(ConsoleLogger.Default);
+        AddColumnProvider(DefaultColumnProviders.Instance);
+
+        AddJob(Job.Default
+            .WithWarmupCount(1)
+            .WithIterationCount(15));
+
+        AddDiagnoser(MemoryDiagnoser.Default);
+        AddExporter(JsonExporter.Full);
+        AddExporter(JsonExporter.FullCompressed);
+        AddExporter(MarkdownExporter.GitHub);
+    }
+}

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/BulkRepositoryBenchmarks.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/BulkRepositoryBenchmarks.cs
@@ -1,0 +1,107 @@
+using BenchmarkDotNet.Attributes;
+using Dilcore.MongoDB.Abstractions.Repositories;
+using Dilcore.MongoDB.Benchmarks.Infrastructure;
+using Dilcore.MongoDB.Benchmarks.Models;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Benchmarks;
+
+/// <summary>
+/// Bulk store/delete vs raw <see cref="IMongoCollection{TDocument}.BulkWriteAsync"/>.
+/// </summary>
+public class BulkRepositoryBenchmarks
+{
+    private MongoBenchmarkFixture _fixture = null!;
+    private IGenericBulkRepository<BenchmarkEntity> _bulkRepository = null!;
+    private IMongoCollection<BenchmarkEntity> _collection = null!;
+    private BenchmarkEntity[] _batch = null!;
+    private HashSet<Guid> _batchIds = null!;
+
+    [Params(100, 1000)]
+    public int BatchSize { get; set; }
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        _fixture = await MongoBenchmarkFixture.StartAsync().ConfigureAwait(false);
+        _fixture.ConfigureServices(
+            databaseName: "bench-bulk",
+            collectionName: "bulk-entities",
+            bindingKey: "bulk",
+            softDelete: true,
+            withBulk: true);
+
+        _bulkRepository = _fixture.BulkRepository;
+        _collection = _fixture.Collection;
+    }
+
+    [GlobalCleanup]
+    public async Task GlobalCleanup()
+    {
+        await _fixture.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [IterationSetup(Targets = [nameof(RawDriver_BulkInsert), nameof(Library_BulkStoreAsync)])]
+    public void SetupInsertBatch()
+    {
+        _batch = new BenchmarkEntity[BatchSize];
+        for (var i = 0; i < BatchSize; i++)
+        {
+            _batch[i] = MongoBenchmarkFixture.NewEntity(name: $"bulk-{i}", value: i);
+        }
+    }
+
+    [Benchmark]
+    public async Task RawDriver_BulkInsert()
+    {
+        var writes = new WriteModel<BenchmarkEntity>[_batch.Length];
+        for (var i = 0; i < _batch.Length; i++)
+        {
+            var entity = _batch[i];
+            entity.Id = Guid.NewGuid();
+            entity.ETag = 1;
+            entity.CreatedAt = DateTime.UtcNow;
+            entity.UpdatedAt = entity.CreatedAt;
+            writes[i] = new InsertOneModel<BenchmarkEntity>(entity);
+        }
+
+        await _collection.BulkWriteAsync(writes).ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_BulkStoreAsync()
+    {
+        await _bulkRepository.BulkStoreAsync(_batch).ConfigureAwait(false);
+    }
+
+    [IterationSetup(Targets = [nameof(RawDriver_BulkDelete), nameof(Library_BulkDeleteAsync)])]
+    public void SetupDeleteBatch()
+    {
+        _batch = new BenchmarkEntity[BatchSize];
+        for (var i = 0; i < BatchSize; i++)
+        {
+            _batch[i] = MongoBenchmarkFixture.NewEntity(name: $"bulk-del-{i}", value: i);
+        }
+
+        _bulkRepository.BulkStoreAsync(_batch).GetAwaiter().GetResult();
+        _batchIds = _batch.Select(x => x.Id).ToHashSet();
+    }
+
+    [Benchmark]
+    public async Task RawDriver_BulkDelete()
+    {
+        var update = Builders<BenchmarkEntity>.Update
+            .Set(x => x.IsDeleted, true)
+            .Set(x => x.UpdatedAt, DateTime.UtcNow);
+        await _collection.UpdateManyAsync(
+                Builders<BenchmarkEntity>.Filter.In(x => x.Id, _batchIds),
+                update)
+            .ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_BulkDeleteAsync()
+    {
+        await _bulkRepository.BulkDeleteAsync(x => _batchIds.Contains(x.Id)).ConfigureAwait(false);
+    }
+}

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/ColdStartBenchmarks.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/ColdStartBenchmarks.cs
@@ -22,6 +22,8 @@ public class ColdStartBenchmarks
     [Benchmark(Baseline = true)]
     public IMongoCollection<BenchmarkEntity> RawDriver_CreateClientAndGetCollection()
     {
+        // Intentionally not disposed: cold-start measures client construction + first collection
+        // resolve only; disposing would close the pool the returned collection depends on.
         var client = new MongoClient(ConnectionString);
         return client.GetDatabase("bench-coldstart").GetCollection<BenchmarkEntity>("entities");
     }

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/ColdStartBenchmarks.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/ColdStartBenchmarks.cs
@@ -1,0 +1,52 @@
+using BenchmarkDotNet.Attributes;
+using Dilcore.MongoDB.Abstractions.Repositories;
+using Dilcore.MongoDB.Benchmarks.Models;
+using Dilcore.MongoDB.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Benchmarks;
+
+/// <summary>
+/// Cold-start: DI registration + first repository resolve vs raw MongoClient + collection.
+/// No live MongoDB connection is required (client construction is lazy).
+/// </summary>
+/// <remarks>
+/// Telemetry on/off overhead budgets from docs/product/v2-goals.md are deferred until
+/// M6 instrumentation lands (GitHub issues #33 / #34).
+/// </remarks>
+public class ColdStartBenchmarks
+{
+    private const string ConnectionString = "mongodb://127.0.0.1:27017";
+
+    [Benchmark(Baseline = true)]
+    public IMongoCollection<BenchmarkEntity> RawDriver_CreateClientAndGetCollection()
+    {
+        var client = new MongoClient(ConnectionString);
+        return client.GetDatabase("bench-coldstart").GetCollection<BenchmarkEntity>("entities");
+    }
+
+    [Benchmark]
+    public IGenericRepository<BenchmarkEntity> Library_ConfigureDiAndResolveBinding()
+    {
+        var services = new ServiceCollection();
+        services.AddMongoDb(mongo => mongo
+            .AddCluster("primary", c => c.UseConnectionString(ConnectionString))
+            .AddDatabase("bench-coldstart", db =>
+            {
+                db.OnCluster("primary");
+                db.AddDocumentBinding<BenchmarkEntity>("e1", d => d
+                    .WithCollectionName("entities"));
+            }));
+
+        // Intentionally not disposed: cold-start measures construction + first resolve only.
+        var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true
+        });
+
+        var scope = provider.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<IGenericRepository<BenchmarkEntity>>();
+    }
+}

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/ColdStartBenchmarks.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/ColdStartBenchmarks.cs
@@ -22,9 +22,7 @@ public class ColdStartBenchmarks
     [Benchmark(Baseline = true)]
     public IMongoCollection<BenchmarkEntity> RawDriver_CreateClientAndGetCollection()
     {
-        // Intentionally not disposed: cold-start measures client construction + first collection
-        // resolve only; disposing would close the pool the returned collection depends on.
-        var client = new MongoClient(ConnectionString);
+        using var client = new MongoClient(ConnectionString);
         return client.GetDatabase("bench-coldstart").GetCollection<BenchmarkEntity>("entities");
     }
 

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/Dilcore.MongoDB.Benchmarks.csproj
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/Dilcore.MongoDB.Benchmarks.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>false</IsTestProject>
+        <RootNamespace>Dilcore.MongoDB.Benchmarks</RootNamespace>
+        <AssemblyName>Dilcore.MongoDB.Benchmarks</AssemblyName>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Testcontainers.MongoDb" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Dilcore.MongoDB\Dilcore.MongoDB.csproj" />
+        <ProjectReference Include="..\..\..\src\Dilcore.MongoDB.Abstractions\Dilcore.MongoDB.Abstractions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/Infrastructure/MongoBenchmarkFixture.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/Infrastructure/MongoBenchmarkFixture.cs
@@ -1,0 +1,135 @@
+using Dilcore.MongoDB.Abstractions.Repositories;
+using Dilcore.MongoDB.Benchmarks.Models;
+using Dilcore.MongoDB.DependencyInjection;
+using Dilcore.MongoDB.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Testcontainers.MongoDb;
+
+namespace Dilcore.MongoDB.Benchmarks.Infrastructure;
+
+/// <summary>
+/// Shared Testcontainers MongoDB lifecycle for repository benchmarks.
+/// Mirrors <c>test/Repositories.IntegrationTests/Infrastructure/BaseIntegrationTests</c>.
+/// </summary>
+public sealed class MongoBenchmarkFixture : IAsyncDisposable
+{
+    private readonly MongoDbContainer _container;
+    private ServiceProvider? _provider;
+    private IServiceScope? _scope;
+    private IMongoClient? _client;
+
+    private MongoBenchmarkFixture(MongoDbContainer container)
+    {
+        _container = container;
+    }
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public IServiceProvider Services =>
+        _scope?.ServiceProvider
+        ?? throw new InvalidOperationException("Call ConfigureServices before resolving services.");
+
+    public IRepositoryResolver Resolver => Services.GetRequiredService<IRepositoryResolver>();
+
+    public IGenericRepository<BenchmarkEntity> Repository =>
+        Services.GetRequiredService<IGenericRepository<BenchmarkEntity>>();
+
+    public IGenericBulkRepository<BenchmarkEntity> BulkRepository =>
+        Services.GetRequiredService<IGenericBulkRepository<BenchmarkEntity>>();
+
+    public IGenericProjectionRepository<BenchmarkEntity> ProjectionRepository =>
+        Services.GetRequiredService<IGenericProjectionRepository<BenchmarkEntity>>();
+
+    public IMongoCollection<BenchmarkEntity> Collection { get; private set; } = null!;
+
+    public static async Task<MongoBenchmarkFixture> StartAsync()
+    {
+        var container = new MongoDbBuilder("mongo:7.0").Build();
+        await container.StartAsync().ConfigureAwait(false);
+        return new MongoBenchmarkFixture(container);
+    }
+
+    public void ConfigureServices(Action<IMongoDbBuilder> configure, string databaseName, string collectionName)
+    {
+        _scope?.Dispose();
+        _provider?.Dispose();
+
+        var services = new ServiceCollection();
+        services.AddMongoDb(configure);
+
+        _provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true
+        });
+        _scope = _provider.CreateScope();
+
+        // Resolve the library-owned client first so Guid serializer registration
+        // happens via MongoClientHolder before any raw GetCollection mapping.
+        _client = Services.GetRequiredKeyedService<IMongoClient>("primary");
+        Collection = _client.GetDatabase(databaseName).GetCollection<BenchmarkEntity>(collectionName);
+    }
+
+    public void ConfigureServices(
+        string databaseName,
+        string collectionName,
+        string bindingKey = "bench",
+        bool softDelete = false,
+        bool withBulk = false,
+        bool withProjection = false)
+    {
+        ConfigureServices(
+            mongo => mongo
+                .AddCluster("primary", c => c.UseConnectionString(ConnectionString))
+                .AddDatabase(databaseName, db =>
+                {
+                    db.OnCluster("primary");
+                    db.AddDocumentBinding<BenchmarkEntity>(bindingKey, d =>
+                    {
+                        d.WithCollectionName(collectionName);
+                        if (softDelete)
+                        {
+                            d.WithSoftDelete();
+                        }
+
+                        if (withBulk)
+                        {
+                            d.WithBulkRepository();
+                        }
+
+                        if (withProjection)
+                        {
+                            d.WithProjectionRepository();
+                        }
+                    });
+                }),
+            databaseName,
+            collectionName);
+    }
+
+    public IMongoCollection<BenchmarkEntity> GetCollection(string databaseName, string collectionName)
+    {
+        var client = _client
+            ?? Services.GetRequiredKeyedService<IMongoClient>("primary");
+        return client.GetDatabase(databaseName).GetCollection<BenchmarkEntity>(collectionName);
+    }
+
+    public static BenchmarkEntity NewEntity(string? name = null, int value = 0) =>
+        new()
+        {
+            Name = name ?? $"entity-{Guid.NewGuid():N}",
+            Value = value
+        };
+
+    public async ValueTask DisposeAsync()
+    {
+        _scope?.Dispose();
+        if (_provider is not null)
+        {
+            await _provider.DisposeAsync().ConfigureAwait(false);
+        }
+
+        await _container.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/Models/BenchmarkEntity.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/Models/BenchmarkEntity.cs
@@ -1,0 +1,28 @@
+using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Policies;
+
+namespace Dilcore.MongoDB.Benchmarks.Models;
+
+public sealed class BenchmarkEntity : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
+{
+    public Guid Id { get; set; }
+
+    public long ETag { get; set; }
+
+    public bool IsDeleted { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+
+    public string? Name { get; set; }
+
+    public int Value { get; set; }
+}
+
+public sealed class BenchmarkEntityProjection
+{
+    public Guid Id { get; set; }
+
+    public string? Name { get; set; }
+}

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/Program.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/Program.cs
@@ -1,0 +1,16 @@
+using BenchmarkDotNet.Running;
+
+namespace Dilcore.MongoDB.Benchmarks;
+
+public static class Program
+{
+    public static int Main(string[] args)
+    {
+        return BenchmarkSwitcher
+            .FromAssembly(typeof(Program).Assembly)
+            .Run(args, BenchmarkConfig.Default)
+            .Any(summary => summary.HasCriticalValidationErrors)
+            ? 1
+            : 0;
+    }
+}

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/ProjectionRepositoryBenchmarks.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/ProjectionRepositoryBenchmarks.cs
@@ -1,0 +1,86 @@
+using BenchmarkDotNet.Attributes;
+using Dilcore.MongoDB.Abstractions.Repositories;
+using Dilcore.MongoDB.Benchmarks.Infrastructure;
+using Dilcore.MongoDB.Benchmarks.Models;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Benchmarks;
+
+/// <summary>
+/// Typed projection queries vs raw driver projection pipelines.
+/// </summary>
+public class ProjectionRepositoryBenchmarks
+{
+    private const int SeedCount = 100;
+
+    private MongoBenchmarkFixture _fixture = null!;
+    private IGenericProjectionRepository<BenchmarkEntity> _projectionRepository = null!;
+    private IMongoCollection<BenchmarkEntity> _collection = null!;
+    private Guid _existingId;
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        _fixture = await MongoBenchmarkFixture.StartAsync().ConfigureAwait(false);
+        _fixture.ConfigureServices(
+            databaseName: "bench-projection",
+            collectionName: "projection-entities",
+            bindingKey: "projection",
+            withBulk: true,
+            withProjection: true);
+
+        _projectionRepository = _fixture.ProjectionRepository;
+        _collection = _fixture.Collection;
+
+        var entities = new BenchmarkEntity[SeedCount];
+        for (var i = 0; i < SeedCount; i++)
+        {
+            entities[i] = MongoBenchmarkFixture.NewEntity(name: $"proj-{i}", value: i);
+        }
+
+        await _fixture.BulkRepository.BulkStoreAsync(entities).ConfigureAwait(false);
+        _existingId = entities[0].Id;
+    }
+
+    [GlobalCleanup]
+    public async Task GlobalCleanup()
+    {
+        await _fixture.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task RawDriver_ProjectOne()
+    {
+        await _collection.Find(Builders<BenchmarkEntity>.Filter.Eq(x => x.Id, _existingId))
+            .Project(x => new BenchmarkEntityProjection { Id = x.Id, Name = x.Name })
+            .FirstOrDefaultAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_GetProjectedAsync()
+    {
+        var filter = Builders<BenchmarkEntity>.Filter.Eq(x => x.Id, _existingId);
+        await _projectionRepository.GetAsync(
+                filter,
+                x => new BenchmarkEntityProjection { Id = x.Id, Name = x.Name })
+            .ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task RawDriver_ProjectList()
+    {
+        await _collection.Find(FilterDefinition<BenchmarkEntity>.Empty)
+            .Project(x => new BenchmarkEntityProjection { Id = x.Id, Name = x.Name })
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_GetListProjectedAsync()
+    {
+        await _projectionRepository.GetListAsync(
+                x => new BenchmarkEntityProjection { Id = x.Id, Name = x.Name })
+            .ConfigureAwait(false);
+    }
+}

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/RepositoryCrudBenchmarks.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/RepositoryCrudBenchmarks.cs
@@ -157,6 +157,7 @@ public class RepositoryCrudBenchmarks
         {
             foreach (var _ in cursor.Current)
             {
+                // Drain the cursor to measure full enumeration cost.
             }
         }
     }
@@ -167,6 +168,7 @@ public class RepositoryCrudBenchmarks
         await foreach (var _ in _repository.GetAsyncEnumerable(FilterDefinition<BenchmarkEntity>.Empty)
                            .ConfigureAwait(false))
         {
+            // Drain the enumerable to measure full enumeration cost.
         }
     }
 

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/RepositoryCrudBenchmarks.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/RepositoryCrudBenchmarks.cs
@@ -1,0 +1,248 @@
+using BenchmarkDotNet.Attributes;
+using Dilcore.MongoDB.Abstractions.Repositories;
+using Dilcore.MongoDB.Benchmarks.Infrastructure;
+using Dilcore.MongoDB.Benchmarks.Models;
+using Dilcore.MongoDB.Extensions;
+using Dilcore.MongoDB.Repositories;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Benchmarks;
+
+/// <summary>
+/// Steady-state repository CRUD vs raw driver against Testcontainers MongoDB.
+/// Soft-delete and hard-delete bindings share one DI container (one Guid serializer registration).
+/// </summary>
+public class RepositoryCrudBenchmarks
+{
+    private const int SeedCount = 100;
+    private const string SoftBindingKey = "crud-soft";
+    private const string HardBindingKey = "crud-hard";
+
+    private MongoBenchmarkFixture _fixture = null!;
+    private IGenericRepository<BenchmarkEntity> _repository = null!;
+    private IMongoCollection<BenchmarkEntity> _collection = null!;
+    private IGenericRepository<BenchmarkEntity> _hardDeleteRepository = null!;
+    private IMongoCollection<BenchmarkEntity> _hardDeleteCollection = null!;
+    private Guid _existingId;
+    private BenchmarkEntity _updateTarget = null!;
+    private BenchmarkEntity _softDeleteTarget = null!;
+    private BenchmarkEntity _hardDeleteTarget = null!;
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        _fixture = await MongoBenchmarkFixture.StartAsync().ConfigureAwait(false);
+        _fixture.ConfigureServices(
+            mongo => mongo
+                .AddCluster("primary", c => c.UseConnectionString(_fixture.ConnectionString))
+                .AddDatabase("bench-crud", db =>
+                {
+                    db.OnCluster("primary");
+                    db.AddDocumentBinding<BenchmarkEntity>(SoftBindingKey, d => d
+                        .WithCollectionName("crud-soft")
+                        .WithSoftDelete());
+                    db.AddDocumentBinding<BenchmarkEntity>(HardBindingKey, d => d
+                        .WithCollectionName("crud-hard"));
+                }),
+            databaseName: "bench-crud",
+            collectionName: "crud-soft");
+
+        var resolver = _fixture.Resolver;
+        _repository = resolver.GetRepository<BenchmarkEntity>(SoftBindingKey);
+        _hardDeleteRepository = resolver.GetRepository<BenchmarkEntity>(HardBindingKey);
+        _collection = _fixture.Collection;
+        _hardDeleteCollection = _fixture.GetCollection("bench-crud", "crud-hard");
+
+        for (var i = 0; i < SeedCount; i++)
+        {
+            var entity = MongoBenchmarkFixture.NewEntity(name: $"seed-{i}", value: i);
+            var result = await _repository.StoreAsync(entity).ConfigureAwait(false);
+            if (i == 0)
+            {
+                _existingId = result.Value.Id;
+            }
+        }
+    }
+
+    [GlobalCleanup]
+    public async Task GlobalCleanup()
+    {
+        await _fixture.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task RawDriver_Insert()
+    {
+        var entity = MongoBenchmarkFixture.NewEntity();
+        entity.Id = Guid.NewGuid();
+        entity.ETag = 1;
+        entity.CreatedAt = DateTime.UtcNow;
+        entity.UpdatedAt = entity.CreatedAt;
+        await _collection.InsertOneAsync(entity).ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_Store_Insert()
+    {
+        var entity = MongoBenchmarkFixture.NewEntity();
+        await _repository.StoreAsync(entity).ConfigureAwait(false);
+    }
+
+    [IterationSetup(Targets = [nameof(RawDriver_Replace), nameof(Library_Store_Update)])]
+    public void SetupUpdateTarget()
+    {
+        _updateTarget = MongoBenchmarkFixture.NewEntity();
+        var stored = _repository.StoreAsync(_updateTarget).GetAwaiter().GetResult();
+        _updateTarget = stored.Value;
+        _updateTarget.Name = "updated-" + Guid.NewGuid().ToString("N");
+        _updateTarget.Value++;
+    }
+
+    [Benchmark]
+    public async Task RawDriver_Replace()
+    {
+        _updateTarget.ETag++;
+        _updateTarget.UpdatedAt = DateTime.UtcNow;
+        await _collection.ReplaceOneAsync(
+                Builders<BenchmarkEntity>.Filter.Eq(x => x.Id, _updateTarget.Id),
+                _updateTarget)
+            .ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_Store_Update()
+    {
+        await _repository.StoreAsync(_updateTarget).ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task RawDriver_FindById()
+    {
+        await _collection.Find(Builders<BenchmarkEntity>.Filter.Eq(x => x.Id, _existingId))
+            .FirstOrDefaultAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_GetAsync()
+    {
+        await _repository.GetAsync(_existingId).ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task RawDriver_FindList()
+    {
+        await _collection.Find(FilterDefinition<BenchmarkEntity>.Empty)
+            .Limit(SeedCount)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_GetListAsync()
+    {
+        await _repository.GetListAsync().ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task RawDriver_FindEnumerable()
+    {
+        using var cursor = await _collection
+            .Find(FilterDefinition<BenchmarkEntity>.Empty)
+            .Limit(SeedCount)
+            .ToCursorAsync()
+            .ConfigureAwait(false);
+
+        while (await cursor.MoveNextAsync().ConfigureAwait(false))
+        {
+            foreach (var _ in cursor.Current)
+            {
+            }
+        }
+    }
+
+    [Benchmark]
+    public async Task Library_GetAsyncEnumerable()
+    {
+        await foreach (var _ in _repository.GetAsyncEnumerable(FilterDefinition<BenchmarkEntity>.Empty)
+                           .ConfigureAwait(false))
+        {
+        }
+    }
+
+    [Benchmark]
+    public async Task RawDriver_Count()
+    {
+        await _collection.CountDocumentsAsync(FilterDefinition<BenchmarkEntity>.Empty).ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_CountAsync()
+    {
+        await _repository.CountAsync(FilterDefinition<BenchmarkEntity>.Empty).ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task RawDriver_Any()
+    {
+        await _collection.Find(FilterDefinition<BenchmarkEntity>.Empty)
+            .Limit(1)
+            .FirstOrDefaultAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_HasAnyAsync()
+    {
+        await _repository.HasAnyAsync(FilterDefinition<BenchmarkEntity>.Empty).ConfigureAwait(false);
+    }
+
+    [IterationSetup(Targets = [nameof(Library_Delete_Soft), nameof(RawDriver_Delete_Soft)])]
+    public void SetupSoftDeleteTarget()
+    {
+        _softDeleteTarget = MongoBenchmarkFixture.NewEntity();
+        var stored = _repository.StoreAsync(_softDeleteTarget).GetAwaiter().GetResult();
+        _softDeleteTarget = stored.Value;
+    }
+
+    [Benchmark]
+    public async Task RawDriver_Delete_Soft()
+    {
+        var update = Builders<BenchmarkEntity>.Update
+            .Set(x => x.IsDeleted, true)
+            .Set(x => x.UpdatedAt, DateTime.UtcNow);
+        await _collection.UpdateOneAsync(
+                Builders<BenchmarkEntity>.Filter.Eq(x => x.Id, _softDeleteTarget.Id),
+                update)
+            .ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_Delete_Soft()
+    {
+        await _repository.DeleteAsync(_softDeleteTarget.Id, _softDeleteTarget.ETag).ConfigureAwait(false);
+    }
+
+    [IterationSetup(Targets = [nameof(Library_Delete_Hard), nameof(RawDriver_Delete_Hard)])]
+    public void SetupHardDeleteTarget()
+    {
+        _hardDeleteTarget = MongoBenchmarkFixture.NewEntity();
+        var stored = _hardDeleteRepository.StoreAsync(_hardDeleteTarget).GetAwaiter().GetResult();
+        _hardDeleteTarget = stored.Value;
+    }
+
+    [Benchmark]
+    public async Task RawDriver_Delete_Hard()
+    {
+        await _hardDeleteCollection.DeleteOneAsync(
+                Builders<BenchmarkEntity>.Filter.Eq(x => x.Id, _hardDeleteTarget.Id))
+            .ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task Library_Delete_Hard()
+    {
+        await _hardDeleteRepository.DeleteAsync(_hardDeleteTarget.Id, _hardDeleteTarget.ETag)
+            .ConfigureAwait(false);
+    }
+}

--- a/test/Benchmarks/Dilcore.MongoDB.Benchmarks/TelemetryOverheadBenchmarks.cs
+++ b/test/Benchmarks/Dilcore.MongoDB.Benchmarks/TelemetryOverheadBenchmarks.cs
@@ -1,0 +1,16 @@
+namespace Dilcore.MongoDB.Benchmarks;
+
+/// <summary>
+/// Placeholder for telemetry on/off overhead budgets from
+/// <c>docs/product/v2-goals.md</c> (disabled ≤1%, enabled ≤3%).
+/// </summary>
+/// <remarks>
+/// TODO(#33, #34 / M6): add ActivitySource + Meter instrumentation in the library,
+/// then implement paired steady-state CRUD benchmarks with listeners attached vs absent.
+/// This type intentionally has no <c>[Benchmark]</c> methods so it is not discovered
+/// by BenchmarkDotNet until those features exist.
+/// </remarks>
+public static class TelemetryOverheadBenchmarks
+{
+    // Intentionally empty until M6 observability lands.
+}

--- a/test/IntegrationTests/DiAcceptanceTests.cs
+++ b/test/IntegrationTests/DiAcceptanceTests.cs
@@ -1,4 +1,5 @@
 using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Abstractions.Keys;
 using Dilcore.MongoDB.Abstractions.Namespace;
 using Dilcore.MongoDB.Abstractions.Ownership;
@@ -682,7 +683,7 @@ public class DiAcceptanceTests : BaseIntegrationTests
                 CollectionPrefix: null)));
     }
 
-    public class TestEntity : IDocumentEntity
+    public class TestEntity : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }
@@ -692,7 +693,7 @@ public class DiAcceptanceTests : BaseIntegrationTests
         public int Value { get; set; }
     }
 
-    public class TestEntity1 : IDocumentEntity
+    public class TestEntity1 : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }
@@ -702,7 +703,7 @@ public class DiAcceptanceTests : BaseIntegrationTests
         public int Value { get; set; }
     }
 
-    public class TestEntity2 : IDocumentEntity
+    public class TestEntity2 : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }
@@ -712,7 +713,7 @@ public class DiAcceptanceTests : BaseIntegrationTests
         public string? Value { get; set; }
     }
 
-    public class TestEntity3 : IDocumentEntity
+    public class TestEntity3 : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }

--- a/test/IntegrationTests/MultiClusterAcceptanceTests.cs
+++ b/test/IntegrationTests/MultiClusterAcceptanceTests.cs
@@ -1,4 +1,5 @@
 using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using Dilcore.MongoDB.Extensions;
 using Dilcore.MongoDB.IntegrationTests.Infrastructure;
@@ -127,7 +128,7 @@ public class MultiClusterAcceptanceTests
         (await collectionB.Find(x => x.Value == 1).FirstOrDefaultAsync()).ShouldBeNull();
     }
 
-    private class Order : IDocumentEntity
+    private class Order : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }
@@ -137,7 +138,7 @@ public class MultiClusterAcceptanceTests
         public int Value { get; set; }
     }
 
-    private class PageView : IDocumentEntity
+    private class PageView : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }

--- a/test/Repositories.IntegrationTests/BsonDocumentRepositoryTests.cs
+++ b/test/Repositories.IntegrationTests/BsonDocumentRepositoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Abstractions.Keys;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using Dilcore.MongoDB.Extensions;
@@ -111,7 +112,7 @@ public class BsonDocumentRepositoryTests : BaseIntegrationTests
         }
     }
 
-    public class KeepAliveEntity : IDocumentEntity
+    public class KeepAliveEntity : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }

--- a/test/Repositories.IntegrationTests/GenericBulkRepositoryTests.cs
+++ b/test/Repositories.IntegrationTests/GenericBulkRepositoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using Dilcore.MongoDB.Extensions;
 using Dilcore.MongoDB.Repositories;
@@ -79,7 +80,7 @@ public class GenericBulkRepositoryTests : BaseIntegrationTests
         remaining.ValueOrDefault.Count.ShouldBe(0);
     }
 
-    public class TestEntity1 : IDocumentEntity
+    public class TestEntity1 : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }

--- a/test/Repositories.IntegrationTests/GenericProjectionRepositoryTests.cs
+++ b/test/Repositories.IntegrationTests/GenericProjectionRepositoryTests.cs
@@ -1,4 +1,5 @@
 using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using Dilcore.MongoDB.Extensions;
 using MongoDB.Driver;
@@ -67,7 +68,7 @@ public class GenericProjectionRepositoryTests : BaseIntegrationTests
         projectionResult.ValueOrDefault.Name.ShouldBe(entity.Name);
     }
 
-    public class TestEntity1 : IDocumentEntity
+    public class TestEntity1 : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }

--- a/test/Repositories.IntegrationTests/GenericRepositoryTests.cs
+++ b/test/Repositories.IntegrationTests/GenericRepositoryTests.cs
@@ -1,8 +1,10 @@
 ﻿using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Abstractions.Keys;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using Dilcore.MongoDB.Extensions;
 using Dilcore.MongoDB.Repositories;
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
 
@@ -214,7 +216,7 @@ public class GenericRepositoryTests : BaseIntegrationTests
 
     [BsonDiscriminator(nameof(TestEntity1))]
     [BsonKnownTypes(typeof(DerivedTestEntity1))]
-    public class TestEntity1 : IDocumentEntity
+    public class TestEntity1 : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }
@@ -229,5 +231,118 @@ public class GenericRepositoryTests : BaseIntegrationTests
     public class DerivedTestEntity1 : TestEntity1
     {
         public string? SomeValue { get; set; }
+    }
+
+    public class MinimalEntity : IDocumentEntity<Guid>
+    {
+        public Guid Id { get; set; }
+        public string? Name { get; set; }
+    }
+
+    public class ObjectIdEntity : IDocumentEntity<ObjectId>
+    {
+        public ObjectId Id { get; set; }
+        public string? Name { get; set; }
+    }
+}
+
+public class FlexibleDocumentEntityRepositoryTests : BaseIntegrationTests
+{
+    [Test]
+    public async Task MinimalEntity_StoreGetDelete_WorksWithoutPolicies()
+    {
+        var services = new ServiceCollection();
+        var connectionString = MongoDbContainer.GetConnectionString();
+
+        services.AddMongoDb(mongo => mongo
+            .AddCluster("primary", c => c.UseConnectionString(connectionString))
+            .AddDatabase("MinimalDB", db =>
+            {
+                db.OnCluster("primary");
+                db.AddDocumentBinding<GenericRepositoryTests.MinimalEntity>("minimal", d => d
+                    .WithCollectionName("minimalEntities"));
+            }));
+
+        using var provider = AcceptanceServiceProviderFactory.Create(services);
+        using var scope = provider.CreateScope();
+        var repository = scope.ServiceProvider
+            .GetRequiredService<IGenericRepository<GenericRepositoryTests.MinimalEntity>>();
+
+        var entity = new GenericRepositoryTests.MinimalEntity { Name = "min" };
+        var store = await repository.StoreAsync(entity);
+        store.ShouldBeSuccess();
+        store.Value.Id.ShouldNotBe(Guid.Empty);
+        store.Value.Id.Version.ShouldBe(4);
+
+        var get = await repository.GetAsync(
+            Builders<GenericRepositoryTests.MinimalEntity>.Filter.Eq(x => x.Id, store.Value.Id));
+        get.ShouldBeSuccess();
+        get.Value!.Name.ShouldBe("min");
+
+        store.Value.Name = "updated";
+        var update = await repository.StoreAsync(store.Value);
+        update.ShouldBeSuccess();
+        update.Value.Name.ShouldBe("updated");
+
+        var deleted = await repository.DeleteAsync(
+            Builders<GenericRepositoryTests.MinimalEntity>.Filter.Eq(x => x.Id, store.Value.Id));
+        deleted.ShouldBeSuccess();
+        deleted.Value.ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task GuidIdGeneration_SequentialVersion7_ProducesUuidV7()
+    {
+        var services = new ServiceCollection();
+        var connectionString = MongoDbContainer.GetConnectionString();
+
+        services.AddMongoDb(mongo => mongo
+            .AddCluster("primary", c => c.UseConnectionString(connectionString))
+            .AddDatabase("Uuid7DB", db =>
+            {
+                db.OnCluster("primary");
+                db.AddDocumentBinding<GenericRepositoryTests.MinimalEntity>("uuid7", d => d
+                    .WithCollectionName("uuid7Entities")
+                    .WithGuidIdGeneration(GuidIdGenerationStrategy.SequentialVersion7));
+            }));
+
+        using var provider = AcceptanceServiceProviderFactory.Create(services);
+        using var scope = provider.CreateScope();
+        var repository = scope.ServiceProvider
+            .GetRequiredService<IGenericRepository<GenericRepositoryTests.MinimalEntity>>();
+
+        var store = await repository.StoreAsync(new GenericRepositoryTests.MinimalEntity { Name = "v7" });
+        store.ShouldBeSuccess();
+        store.Value.Id.Version.ShouldBe(7);
+    }
+
+    [Test]
+    public async Task ObjectIdEntity_StoreAndGet_Works()
+    {
+        var services = new ServiceCollection();
+        var connectionString = MongoDbContainer.GetConnectionString();
+
+        services.AddMongoDb(mongo => mongo
+            .AddCluster("primary", c => c.UseConnectionString(connectionString))
+            .AddDatabase("ObjectIdDB", db =>
+            {
+                db.OnCluster("primary");
+                db.AddDocumentBinding<GenericRepositoryTests.ObjectIdEntity>("oids", d => d
+                    .WithCollectionName("objectIdEntities"));
+            }));
+
+        using var provider = AcceptanceServiceProviderFactory.Create(services);
+        using var scope = provider.CreateScope();
+        var repository = scope.ServiceProvider
+            .GetRequiredService<IGenericRepository<GenericRepositoryTests.ObjectIdEntity>>();
+
+        var store = await repository.StoreAsync(new GenericRepositoryTests.ObjectIdEntity { Name = "oid" });
+        store.ShouldBeSuccess();
+        store.Value.Id.ShouldNotBe(ObjectId.Empty);
+
+        var get = await repository.GetAsync(
+            Builders<GenericRepositoryTests.ObjectIdEntity>.Filter.Eq(x => x.Id, store.Value.Id));
+        get.ShouldBeSuccess();
+        get.Value!.Name.ShouldBe("oid");
     }
 }

--- a/test/UnitTests/DocumentEntityExtensionsTests.cs
+++ b/test/UnitTests/DocumentEntityExtensionsTests.cs
@@ -2,6 +2,7 @@ using Dilcore.MongoDB.Abstractions;
 using Dilcore.MongoDB.Abstractions.Exceptions;
 using Dilcore.MongoDB.Abstractions.Extensions;
 using Dilcore.MongoDB.Abstractions.Helpers;
+using Dilcore.MongoDB.Abstractions.Policies;
 using AutoFixture.NUnit4;
 using AbstractionsConstants = Dilcore.MongoDB.Abstractions.Constants;
 
@@ -12,7 +13,7 @@ public class DocumentEntityExtensionsTests
     [Test]
     public void DocumentEntity_WithUpdateAt()
     {
-        var entity = new TestEntity();
+        var entity = new FullPolicyEntity();
         entity.UpdatedNow();
 
         entity.UpdatedAt.ShouldBe(DateTime.UtcNow, TimeSpan.FromSeconds(1));
@@ -21,7 +22,7 @@ public class DocumentEntityExtensionsTests
     [Test]
     public void DocumentEntity_WithETag()
     {
-        var entity = new TestEntity();
+        var entity = new FullPolicyEntity();
         entity.GenerateETag();
 
         var expected = MongoDbHelper.GenerateEtag();
@@ -31,10 +32,20 @@ public class DocumentEntityExtensionsTests
     [Test]
     public void DocumentEntity_WithNewId()
     {
-        var entity = new TestEntity();
+        var entity = new FullPolicyEntity();
         entity.NewId();
 
         entity.Id.ShouldNotBe(Guid.Empty);
+    }
+
+    [Test]
+    public void DocumentEntity_WithNewId_SequentialVersion7_SetsUuidVersion7()
+    {
+        var entity = new FullPolicyEntity();
+        entity.NewId(GuidIdGenerationStrategy.SequentialVersion7);
+
+        entity.Id.ShouldNotBe(Guid.Empty);
+        entity.Id.Version.ShouldBe(7);
     }
 
     [Test]
@@ -42,7 +53,7 @@ public class DocumentEntityExtensionsTests
     [InlineAutoData(AbstractionsConstants.EmptyETag)]
     public void DocumentEntity_WithIsNew(long etag)
     {
-        var entity = new TestEntity { ETag = etag };
+        var entity = new FullPolicyEntity { ETag = etag };
 
         entity.IsNew().ShouldBe(etag == AbstractionsConstants.EmptyETag);
     }
@@ -50,14 +61,14 @@ public class DocumentEntityExtensionsTests
     [Test]
     public void DocumentEntity_CheckId_ShouldThrowException_WhenEmpty()
     {
-        var entity = new TestEntity();
+        var entity = new FullPolicyEntity();
         Should.Throw<DocumentIdentifierIsEmptyException>(() => entity.CheckId());
     }
 
     [Test]
     public void DocumentEntity_CheckId_ShouldNotThrowException_WhenNotEmpty()
     {
-        var entity = new TestEntity();
+        var entity = new FullPolicyEntity();
         entity.NewId();
 
         Should.NotThrow(() => entity.CheckId());
@@ -67,7 +78,7 @@ public class DocumentEntityExtensionsTests
     [TestCase(false, true)]
     public void DocumentEntity_IsIdEmpty(bool withId, bool isEmpty)
     {
-        var entity = new TestEntity();
+        var entity = new FullPolicyEntity();
         if (withId)
         {
             entity.NewId();
@@ -79,12 +90,47 @@ public class DocumentEntityExtensionsTests
     [Test]
     public void DocumentEntity_ToBsonUpdateDocument_WrapsInSetOperator()
     {
-        var entity = new TestEntity { Id = Guid.NewGuid(), Value = "x" };
+        var entity = new FullPolicyEntity { Id = Guid.NewGuid(), Value = "x" };
         var bson = entity.ToBsonUpdateDocument();
         bson.Contains("$set").ShouldBeTrue();
     }
 
-    private class TestEntity : IDocumentEntity
+    [Test]
+    public void PolicyAbsent_GenerateETag_IsNoOp()
+    {
+        var entity = new MinimalEntity();
+        Should.NotThrow(() => entity.GenerateETag());
+    }
+
+    [Test]
+    public void PolicyAbsent_CreatedNowAndUpdatedNow_AreNoOps()
+    {
+        var entity = new MinimalEntity();
+        Should.NotThrow(() =>
+        {
+            entity.CreatedNow();
+            entity.UpdatedNow();
+        });
+    }
+
+    [Test]
+    public void PolicyAbsent_IsNew_ReturnsTrue()
+    {
+        var entity = new MinimalEntity { Id = Guid.NewGuid() };
+        entity.IsNew().ShouldBeTrue();
+    }
+
+    [Test]
+    public void PolicyAbsent_NewId_And_IsIdEmpty_Work()
+    {
+        var entity = new MinimalEntity();
+        entity.IsIdEmpty().ShouldBeTrue();
+        entity.NewId();
+        entity.IsIdEmpty().ShouldBeFalse();
+        entity.Id.Version.ShouldBe(4);
+    }
+
+    private class FullPolicyEntity : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }
@@ -92,5 +138,10 @@ public class DocumentEntityExtensionsTests
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public string? Value { get; set; }
+    }
+
+    private class MinimalEntity : IDocumentEntity<Guid>
+    {
+        public Guid Id { get; set; }
     }
 }

--- a/test/UnitTests/MongoDbBuilderValidationTests.cs
+++ b/test/UnitTests/MongoDbBuilderValidationTests.cs
@@ -1,6 +1,8 @@
 using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Bson;
 
 namespace Dilcore.MongoDB.UnitTests;
 
@@ -183,6 +185,44 @@ public class MongoDbBuilderValidationTests
                 })));
     }
 
+    [Test]
+    public void AddMongoDb_SoftDeleteWithoutISoftDeletable_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            services.AddMongoDb(mongo => mongo
+                .AddCluster("primary", c => c.UseConnectionString("mongodb://localhost"))
+                .AddDatabase("app", db =>
+                {
+                    db.OnCluster("primary");
+                    db.AddDocumentBinding<MinimalDoc>("orders", d => d
+                        .WithCollectionName("orders")
+                        .WithSoftDelete());
+                })));
+
+        ex.Message.ShouldContain(nameof(ISoftDeletable));
+    }
+
+    [Test]
+    public void AddMongoDb_GuidIdGenerationOnNonGuidId_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            services.AddMongoDb(mongo => mongo
+                .AddCluster("primary", c => c.UseConnectionString("mongodb://localhost"))
+                .AddDatabase("app", db =>
+                {
+                    db.OnCluster("primary");
+                    db.AddDocumentBinding<ObjectIdDoc>("orders", d => d
+                        .WithCollectionName("orders")
+                        .WithGuidIdGeneration(GuidIdGenerationStrategy.SequentialVersion7));
+                })));
+
+        ex.Message.ShouldContain("IDocumentEntity<Guid>");
+    }
+
     private sealed class NoOpPrefixResolver : Dilcore.MongoDB.Abstractions.Namespace.INamespacePrefixResolver
     {
         public Task<FluentResults.Result<string?>> ResolveAsync(
@@ -191,12 +231,22 @@ public class MongoDbBuilderValidationTests
             Task.FromResult(FluentResults.Result.Ok<string?>(null));
     }
 
-    private class TestDoc : IDocumentEntity
+    private class TestDoc : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDeletable, IAuditableDocument
     {
         public Guid Id { get; set; }
         public long ETag { get; set; }
         public bool IsDeleted { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
+    }
+
+    private class MinimalDoc : IDocumentEntity<Guid>
+    {
+        public Guid Id { get; set; }
+    }
+
+    private class ObjectIdDoc : IDocumentEntity<ObjectId>
+    {
+        public ObjectId Id { get; set; }
     }
 }


### PR DESCRIPTION
## Summary

Introduces a flexible, composable document entity model and adds a benchmarking suite for measuring library overhead vs. the raw MongoDB driver.

**Entity model (M2.5):**
- Adds `IDocumentEntity<TId>` for typed document identifiers, decoupling the id type from the entity contract (see `docs/adr/0002-generic-document-identifier.md`).
- Splits optional cross-cutting concerns out of the core entity contract into composable policy interfaces: `IHasConcurrencyToken` (optimistic concurrency / ETag), `ISoftDeletable`, and `IAuditableDocument`.
- Adds `DocumentIdAccessor` and a `GuidIdGenerationStrategy` to support generic id resolution/generation across identifier types.
- Adapts `GenericMongoDbRepository`, `GenericMongoDbBulkRepository`, `GenericRepositoryExtensions`, and `BaseMongoDbRepository` to the new composable model and policies.
- Improves validation/error handling for document binding configuration (`MongoDocumentBindingBuilder`, `UnsupportedIdentifierTypeException`).
- Updates README, samples, and `PublicAPI.Shipped.txt` to reflect the new entity definitions and usage.

**Benchmarks (M5):**
- Adds a new `Dilcore.MongoDB.Benchmarks` project (BenchmarkDotNet) covering cold start, CRUD, bulk, and projection repository operations, benchmarked against the raw driver.
- Adds a CI workflow (`.github/workflows/benchmarks.yml`) to run benchmarks and post results non-blockingly.
- Updates `CONTRIBUTING.md` with Docker requirements for benchmarks/integration tests and `ROADMAP.md` to reflect the benchmarks suite in CI.

## Closed issues

Part of milestone [M2.5 Flexible Document Entity Model](https://github.com/Dilcore-Official/Dilcore-MongoDb/milestone/13):
- Closes #60 (ADR: decouple document identifier type from `IDocumentEntity`)
- Closes #61 (Decompose `IDocumentEntity` into composable policy interfaces)
- Closes #62 (Adapt generic repositories and collection factory to the composable document entity model)

Part of milestone [M5 Quality & Packaging](https://github.com/Dilcore-Official/Dilcore-MongoDb/milestone/6):
- Closes #31 ([M5] Performance benchmarks for policy and telemetry paths)

## Checklist

- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Tests added or updated when behavior changes
- [x] Docs / ROADMAP / PublicAPI baselines updated when needed
- [x] No secrets or machine-specific paths committed
- [ ] Security-sensitive changes called out for maintainer review

## Test plan

- `dotnet test test/UnitTests -c Release`
- `dotnet test test/IntegrationTests -c Release`
- `dotnet run -c Release --project test/Benchmarks/Dilcore.MongoDB.Benchmarks`