### PR TITLE
feat: configurable BSON serialization conventions (M2.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [architecture]
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: 📥 Checkout
@@ -119,6 +122,8 @@ jobs:
           --no-build
           --configuration Release
           --verbosity normal
+          --collect:"XPlat Code Coverage;Format=cobertura"
+          --results-directory "${{ github.workspace }}/TestResults"
           --logger "trx;LogFileName=full.trx"
 
       - name: 📤 Upload TRX
@@ -127,3 +132,41 @@ jobs:
         with:
           name: full-trx
           path: "**/TestResults/**/*.trx"
+
+      - name: 📊 Merge coverage reports
+        if: always()
+        uses: danielpalme/ReportGenerator-GitHub-Action@5
+        with:
+          reports: "TestResults/**/coverage.cobertura.xml"
+          targetdir: "TestResults/coverage-merged"
+          reporttypes: "Cobertura;MarkdownSummaryGithub"
+
+      - name: 📈 Coverage summary
+        if: always()
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: "TestResults/coverage-merged/Cobertura.xml"
+          badge: true
+          fail_below_min: false
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: false
+          indicators: true
+          output: both
+          thresholds: "60 80"
+
+      - name: 💬 Post coverage comment to PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: always() && github.event_name == 'pull_request'
+        with:
+          header: dotnet-coverage
+          path: code-coverage-results.md
+
+      - name: ☂️ Upload to Codecov
+        uses: codecov/codecov-action@v4
+        if: always()
+        with:
+          files: "TestResults/**/coverage.cobertura.xml"
+          flags: dotnet
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -256,6 +256,39 @@ For prefixes that apply across many databases/bindings without per-builder regis
 
 Fail-closed behavior (require a prefix when missing) is an app policy inside your resolver — return `Result.Fail`.
 
+## Serialization conventions
+
+BSON conventions are **process-wide** (MongoDB.Driver's `ConventionRegistry`) and are registered once during `AddMongoDb`. Unconfigured consumers keep these defaults:
+
+- enums as strings (`BsonType.String`)
+- camelCase element names
+- ignore null members
+- ignore extra elements on deserialize
+
+Override them with `ConfigureConventions`. Calling it more than once on the same builder throws. A later `AddMongoDb` in the same process with different settings also throws; identical settings are idempotent.
+
+```csharp
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Conventions;
+
+services.AddMongoDb(mongo => mongo
+    .ConfigureConventions(conventions => conventions
+        .UseEnumRepresentation(BsonType.Int32)
+        .UseElementNameConvention(new CamelCaseElementNameConvention())
+        .IgnoreIfNull(true)
+        .IgnoreExtraElements(true)
+        .AddConvention(new IgnoreIfDefaultConvention(true))
+        .AddConventionPack("orders-only", new ConventionPack(), type => type == typeof(Order)))
+    .AddCluster("primary", c => c.UseConnectionString(connectionString))
+    .AddDatabase("app", db =>
+    {
+        db.OnCluster("primary");
+        db.AddDocumentBinding<Order>("orders", d => d.WithCollectionName("orders"));
+    }));
+```
+
+Decision: [ADR 0003](docs/adr/0003-serialization-conventions.md) (global defaults, not per-cluster / per-document packs).
+
 ## 📋 Usage Examples
 
 ### Basic Setup (from samples/MongoDb.WebApi.Sample)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Dilcore MongoDB
 
+[![CI](https://github.com/Dilcore-Official/Dilcore-MongoDb/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Dilcore-Official/Dilcore-MongoDb/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Dilcore-Official/Dilcore-MongoDb/graph/badge.svg?token=SZPZ8SWY8K)](https://codecov.io/gh/Dilcore-Official/Dilcore-MongoDb)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/Dilcore-Official/Dilcore-MongoDb?utm_source=oss&utm_medium=github&utm_campaign=Dilcore-Official%2FDilcore-MongoDb&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
+
 An opinionated .NET MongoDB application toolkit: validated multi-cluster / multi-database DI, scoped tenant-aware namespace resolution, and repository helpers over `MongoDB.Driver`.
 
 > **v2 roadmap:** See [ROADMAP.md](ROADMAP.md) and [roadmap issues](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues?q=is%3Aissue+label%3Aroadmap). Package selection: [docs/product/package-selection.md](docs/product/package-selection.md). Naming: [ADR 0001](docs/adr/0001-package-naming.md).
@@ -265,7 +269,9 @@ BSON conventions are **process-wide** (MongoDB.Driver's `ConventionRegistry`) an
 - ignore null members
 - ignore extra elements on deserialize
 
-Override them with `ConfigureConventions`. Calling it more than once on the same builder throws. A later `AddMongoDb` in the same process with different settings also throws; identical settings are idempotent.
+Override them with `ConfigureConventions`. Calling it more than once on the same builder throws. A later `AddMongoDb` in the same process with different settings also throws; identical settings are idempotent only when additional custom conventions, packs, and filters are the same instances (or have real value equality). Separately constructed custom conventions with equivalent intent still conflict.
+
+> **Changing conventions after data exists?** See [ADR 0003 – Rollout guidance](docs/adr/0003-serialization-conventions.md#rollout-guidance) before changing enum representation or element naming for a type with existing documents.
 
 ```csharp
 using MongoDB.Bson;

--- a/docs/adr/0003-serialization-conventions.md
+++ b/docs/adr/0003-serialization-conventions.md
@@ -31,10 +31,18 @@ MongoDB.Driver's `ConventionRegistry` is static and process-wide. Per-cluster, p
 Serialization conventions are **global (process-wide)** and configured at most once per `AddMongoDb` via `IMongoDbBuilder.ConfigureConventions`.
 
 - Defaults: `BsonType.String` enums, `CamelCaseElementNameConvention`, `IgnoreIfNullConvention(true)`, `IgnoreExtraElementsConvention(true)`.
-- Registration is eager during `AddMongoDb` and idempotent when the structural signature matches.
+- Registration is eager during `AddMongoDb` and idempotent only when additional custom conventions/packs/filters are the exact same instances (or have real value equality); equivalent-but-separately-constructed custom conventions are treated as a conflict.
 - A later `AddMongoDb` in the same process with a different signature throws `InvalidOperationException`.
 - Custom `IConvention` / named `IConventionPack` entries (with a type filter) are supported on the same builder.
 - No per-document overrides in this milestone.
+
+### Rollout guidance
+
+Conventions define *serialization* behavior only; they do not rewrite existing documents. Before changing a convention that affects the on-the-wire BSON shape (enum representation, element naming), plan for the stored data:
+
+- **Enum representation / element naming changes:** existing documents keep the old shape. Either run a migration to rewrite stored documents to the new shape, or keep a custom `IConvention`/serializer that can read both shapes until migration completes.
+- **New collections only:** if only new collections need the new convention, scope it with a named `AddConventionPack` + type filter instead of changing the global defaults.
+- Never change conventions for a type with data already persisted under the old shape without one of the above; deserialization can throw or silently misread fields.
 
 ## Consequences
 

--- a/docs/adr/0003-serialization-conventions.md
+++ b/docs/adr/0003-serialization-conventions.md
@@ -1,0 +1,42 @@
+# ADR 0003: Process-wide BSON serialization conventions
+
+- **Status:** Accepted
+- **Date:** 2026-08-18
+- **Issue:** [#63](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/63)
+- **Implements:** [#64](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/64), [#65](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/65)
+
+## Context
+
+`MongoDbCollectionFactory` previously registered one hardcoded, process-wide `ConventionPack` (enum-as-string, camelCase names, ignore-null, ignore-extra-elements) lazily on first collection resolution. Consumers could not opt into enum-as-int, a different naming convention, or extra custom conventions without forking the library.
+
+MongoDB.Driver's `ConventionRegistry` is static and process-wide. Per-cluster, per-database, or per-document packs would still collide unless they used disjoint type filters, and the generic repository remains a single serialization pipeline.
+
+## Decision drivers
+
+- Keep today's defaults when `ConfigureConventions` is not called.
+- Fail closed at startup, not on first request.
+- Match the existing `IMongoDbBuilder` fluent surface.
+- Do not register conventions during ordinary collection resolution.
+
+## Options considered
+
+| Option | Summary | Rejected because |
+|--------|---------|------------------|
+| A. Per-document / per-binding packs | Configure conventions on `AddDocumentBinding` | `ConventionRegistry` is not binding-scoped; class maps are type-global |
+| B. Per-cluster / per-database packs | Nested builder methods | Same process-wide registry; implied isolation would be false |
+| **C. Global defaults on `AddMongoDb`** | One `ConfigureConventions` callback per call | **Accepted** |
+
+## Decision
+
+Serialization conventions are **global (process-wide)** and configured at most once per `AddMongoDb` via `IMongoDbBuilder.ConfigureConventions`.
+
+- Defaults: `BsonType.String` enums, `CamelCaseElementNameConvention`, `IgnoreIfNullConvention(true)`, `IgnoreExtraElementsConvention(true)`.
+- Registration is eager during `AddMongoDb` and idempotent when the structural signature matches.
+- A later `AddMongoDb` in the same process with a different signature throws `InvalidOperationException`.
+- Custom `IConvention` / named `IConventionPack` entries (with a type filter) are supported on the same builder.
+- No per-document overrides in this milestone.
+
+## Consequences
+
+- Multiple hosts or test fixtures in one process must share the same convention settings (or reset registry state in tests).
+- Changing conventions after types have already been class-mapped has no effect on those maps.

--- a/samples/MongoDb.WebApi.Sample/Program.cs
+++ b/samples/MongoDb.WebApi.Sample/Program.cs
@@ -3,6 +3,7 @@ using Dilcore.MongoDB.Abstractions.Policies;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using Dilcore.MongoDB.Extensions;
 using Dilcore.MongoDB.Repositories;
+using MongoDB.Bson;
 using Testcontainers.MongoDb;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -18,6 +19,7 @@ await mongoDbContainer.StartAsync();
 var connectionString = mongoDbContainer.GetConnectionString();
 
 builder.Services.AddMongoDb(mongo => mongo
+    .ConfigureConventions(c => c.UseEnumRepresentation(BsonType.Int32))
     .AddCluster("primary", c => c.UseConnectionString(connectionString))
     .AddDatabase("SampleDB", db =>
     {
@@ -125,8 +127,14 @@ record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 }
 
-/// <summary>Minimal document: identifier only, no optional policies.</summary>
-record Note(string Text) : IDocumentEntity<Guid>
+/// <summary>Minimal document: identifier only, no optional policies. Priority is stored as int via ConfigureConventions.</summary>
+record Note(string Text, NotePriority Priority) : IDocumentEntity<Guid>
 {
     public Guid Id { get; set; }
+}
+
+enum NotePriority
+{
+    Low = 0,
+    High = 1
 }

--- a/samples/MongoDb.WebApi.Sample/Program.cs
+++ b/samples/MongoDb.WebApi.Sample/Program.cs
@@ -127,7 +127,7 @@ record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 }
 
-/// <summary>Minimal document: identifier only, no optional policies. Priority is stored as int via ConfigureConventions.</summary>
+/// <summary>Minimal document with text and priority. Priority is stored as BSON Int32 via ConfigureConventions.</summary>
 record Note(string Text, NotePriority Priority) : IDocumentEntity<Guid>
 {
     public Guid Id { get; set; }

--- a/src/Dilcore.MongoDB/DependencyInjection/ConventionsBuilder.cs
+++ b/src/Dilcore.MongoDB/DependencyInjection/ConventionsBuilder.cs
@@ -63,7 +63,7 @@ internal sealed class ConventionsBuilder : IConventionsBuilder
         ArgumentNullException.ThrowIfNull(pack);
         ArgumentNullException.ThrowIfNull(filter);
 
-        if (name == MongoConventionRegistrar.DefaultPackName)
+        if (name.Equals(MongoConventionRegistrar.DefaultPackName, StringComparison.OrdinalIgnoreCase))
         {
             throw new ArgumentException(
                 $"Convention pack name '{name}' is reserved for the default pack. Choose a different name.",

--- a/src/Dilcore.MongoDB/DependencyInjection/ConventionsBuilder.cs
+++ b/src/Dilcore.MongoDB/DependencyInjection/ConventionsBuilder.cs
@@ -1,0 +1,82 @@
+using Dilcore.MongoDB.Descriptors;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Dilcore.MongoDB.DependencyInjection;
+
+internal sealed class ConventionsBuilder : IConventionsBuilder
+{
+    private BsonType _enumRepresentation = BsonType.String;
+    private IConvention _elementNameConvention = new CamelCaseElementNameConvention();
+    private bool _ignoreIfNull = true;
+    private bool _ignoreExtraElements = true;
+    private readonly List<IConvention> _additionalConventions = [];
+    private readonly List<AdditionalConventionPack> _additionalPacks = [];
+    private readonly HashSet<string> _packNames = new(StringComparer.Ordinal);
+
+    public IConventionsBuilder UseEnumRepresentation(BsonType representation)
+    {
+        switch (representation)
+        {
+            case BsonType.String:
+            case BsonType.Int32:
+            case BsonType.Int64:
+                _enumRepresentation = representation;
+                return this;
+            default:
+                throw new ArgumentException(
+                    $"Enum representation '{representation}' is not supported. Use BsonType.String, BsonType.Int32, or BsonType.Int64.",
+                    nameof(representation));
+        }
+    }
+
+    public IConventionsBuilder UseElementNameConvention(IConvention convention)
+    {
+        ArgumentNullException.ThrowIfNull(convention);
+        _elementNameConvention = convention;
+        return this;
+    }
+
+    public IConventionsBuilder IgnoreIfNull(bool ignore = true)
+    {
+        _ignoreIfNull = ignore;
+        return this;
+    }
+
+    public IConventionsBuilder IgnoreExtraElements(bool ignore = true)
+    {
+        _ignoreExtraElements = ignore;
+        return this;
+    }
+
+    public IConventionsBuilder AddConvention(IConvention convention)
+    {
+        ArgumentNullException.ThrowIfNull(convention);
+        _additionalConventions.Add(convention);
+        return this;
+    }
+
+    public IConventionsBuilder AddConventionPack(string name, IConventionPack pack, Func<Type, bool> filter)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(pack);
+        ArgumentNullException.ThrowIfNull(filter);
+
+        if (!_packNames.Add(name))
+        {
+            throw new InvalidOperationException(
+                $"Duplicate convention pack name '{name}'. Each AddConventionPack name must be unique.");
+        }
+
+        _additionalPacks.Add(new AdditionalConventionPack(name, pack, filter));
+        return this;
+    }
+
+    internal ConventionsDescriptor Build() => new(
+        _enumRepresentation,
+        _elementNameConvention,
+        _ignoreIfNull,
+        _ignoreExtraElements,
+        _additionalConventions.ToList(),
+        _additionalPacks.ToList());
+}

--- a/src/Dilcore.MongoDB/DependencyInjection/ConventionsBuilder.cs
+++ b/src/Dilcore.MongoDB/DependencyInjection/ConventionsBuilder.cs
@@ -1,4 +1,5 @@
 using Dilcore.MongoDB.Descriptors;
+using Dilcore.MongoDB.Internal;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Conventions;
 
@@ -61,6 +62,13 @@ internal sealed class ConventionsBuilder : IConventionsBuilder
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(pack);
         ArgumentNullException.ThrowIfNull(filter);
+
+        if (name == MongoConventionRegistrar.DefaultPackName)
+        {
+            throw new ArgumentException(
+                $"Convention pack name '{name}' is reserved for the default pack. Choose a different name.",
+                nameof(name));
+        }
 
         if (!_packNames.Add(name))
         {

--- a/src/Dilcore.MongoDB/DependencyInjection/IConventionsBuilder.cs
+++ b/src/Dilcore.MongoDB/DependencyInjection/IConventionsBuilder.cs
@@ -1,0 +1,19 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Dilcore.MongoDB.DependencyInjection;
+
+public interface IConventionsBuilder
+{
+    IConventionsBuilder UseEnumRepresentation(BsonType representation);
+
+    IConventionsBuilder UseElementNameConvention(IConvention convention);
+
+    IConventionsBuilder IgnoreIfNull(bool ignore = true);
+
+    IConventionsBuilder IgnoreExtraElements(bool ignore = true);
+
+    IConventionsBuilder AddConvention(IConvention convention);
+
+    IConventionsBuilder AddConventionPack(string name, IConventionPack pack, Func<Type, bool> filter);
+}

--- a/src/Dilcore.MongoDB/DependencyInjection/IMongoDbBuilder.cs
+++ b/src/Dilcore.MongoDB/DependencyInjection/IMongoDbBuilder.cs
@@ -5,4 +5,6 @@ public interface IMongoDbBuilder
     IMongoDbBuilder AddCluster(string name, Action<IMongoClusterBuilder> configure);
 
     IMongoDbBuilder AddDatabase(string name, Action<IMongoDatabaseBuilder> configure);
+
+    IMongoDbBuilder ConfigureConventions(Action<IConventionsBuilder> configure);
 }

--- a/src/Dilcore.MongoDB/DependencyInjection/MongoDbBuilder.cs
+++ b/src/Dilcore.MongoDB/DependencyInjection/MongoDbBuilder.cs
@@ -10,6 +10,23 @@ internal sealed class MongoDbBuilder : IMongoDbBuilder
     private readonly HashSet<string> _clusterNames = new(StringComparer.Ordinal);
     private readonly HashSet<string> _databaseNames = new(StringComparer.Ordinal);
     private readonly HashSet<string> _bindingNames = new(StringComparer.Ordinal);
+    private readonly ConventionsBuilder _conventions = new();
+    private bool _conventionsConfigured;
+
+    public IMongoDbBuilder ConfigureConventions(Action<IConventionsBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        if (_conventionsConfigured)
+        {
+            throw new InvalidOperationException(
+                "ConfigureConventions has already been called. Call it at most once per AddMongoDb.");
+        }
+
+        _conventionsConfigured = true;
+        configure(_conventions);
+        return this;
+    }
 
     public IMongoDbBuilder AddCluster(string name, Action<IMongoClusterBuilder> configure)
     {
@@ -64,7 +81,8 @@ internal sealed class MongoDbBuilder : IMongoDbBuilder
         {
             Clusters = _clusters.ToList(),
             Databases = _databases.ToList(),
-            Bindings = _bindings.ToList()
+            Bindings = _bindings.ToList(),
+            Conventions = _conventions.Build()
         };
     }
 

--- a/src/Dilcore.MongoDB/Descriptors/ConventionsDescriptor.cs
+++ b/src/Dilcore.MongoDB/Descriptors/ConventionsDescriptor.cs
@@ -1,0 +1,26 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Dilcore.MongoDB.Descriptors;
+
+internal sealed record AdditionalConventionPack(
+    string Name,
+    IConventionPack Pack,
+    Func<Type, bool> Filter);
+
+internal sealed record ConventionsDescriptor(
+    BsonType EnumRepresentation,
+    IConvention ElementNameConvention,
+    bool IgnoreIfNull,
+    bool IgnoreExtraElements,
+    IReadOnlyList<IConvention> AdditionalConventions,
+    IReadOnlyList<AdditionalConventionPack> AdditionalPacks)
+{
+    public static ConventionsDescriptor CreateDefault() => new(
+        BsonType.String,
+        new CamelCaseElementNameConvention(),
+        IgnoreIfNull: true,
+        IgnoreExtraElements: true,
+        AdditionalConventions: [],
+        AdditionalPacks: []);
+}

--- a/src/Dilcore.MongoDB/Descriptors/MongoRegistrationGraph.cs
+++ b/src/Dilcore.MongoDB/Descriptors/MongoRegistrationGraph.cs
@@ -7,6 +7,7 @@ internal sealed class MongoRegistrationGraph
     public required IReadOnlyList<ClusterDescriptor> Clusters { get; init; }
     public required IReadOnlyList<DatabaseDescriptor> Databases { get; init; }
     public required IReadOnlyList<DocumentBindingDescriptor> Bindings { get; init; }
+    public required ConventionsDescriptor Conventions { get; init; }
 
     public ClusterDescriptor GetCluster(MongoClusterKey key) =>
         Clusters.First(c => c.Key.Equals(key));

--- a/src/Dilcore.MongoDB/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Dilcore.MongoDB/Extensions/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class ServiceCollectionExtensions
         var builder = new MongoDbBuilder();
         configure(builder);
         var graph = builder.Build();
+        MongoConventionRegistrar.EnsureRegistered(graph.Conventions);
 
         services.AddSingleton(graph);
         // Default static-prefix contributor. Apps may register additional

--- a/src/Dilcore.MongoDB/Internal/MongoConventionRegistrar.cs
+++ b/src/Dilcore.MongoDB/Internal/MongoConventionRegistrar.cs
@@ -44,13 +44,11 @@ internal static class MongoConventionRegistrar
                 pack.Add(additional);
             }
 
-            foreach (var additionalPack in conventions.AdditionalPacks)
+            if (conventions.AdditionalPacks.Any(additionalPack =>
+                    additionalPack.Name.Equals(DefaultPackName, StringComparison.OrdinalIgnoreCase)))
             {
-                if (additionalPack.Name == DefaultPackName)
-                {
-                    throw new InvalidOperationException(
-                        $"Convention pack name '{DefaultPackName}' is reserved for the default pack. Choose a different name.");
-                }
+                throw new InvalidOperationException(
+                    $"Convention pack name '{DefaultPackName}' is reserved for the default pack. Choose a different name.");
             }
 
             ConventionRegistry.Register(DefaultPackName, pack, _ => true);

--- a/src/Dilcore.MongoDB/Internal/MongoConventionRegistrar.cs
+++ b/src/Dilcore.MongoDB/Internal/MongoConventionRegistrar.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Dilcore.MongoDB.Descriptors;
 using MongoDB.Bson.Serialization.Conventions;
 
@@ -89,12 +90,12 @@ internal static class MongoConventionRegistrar
 
     private static string ComputeSignature(ConventionsDescriptor conventions)
     {
-        var additionalConventionTypes = string.Join(
+        var additionalConventions = string.Join(
             ",",
-            conventions.AdditionalConventions.Select(c => c.GetType().FullName));
+            conventions.AdditionalConventions.Select(DescribeConvention));
         var additionalPacks = string.Join(
             ",",
-            conventions.AdditionalPacks.Select(p => $"{p.Name}:{p.Pack.GetType().FullName}"));
+            conventions.AdditionalPacks.Select(DescribePack));
 
         return string.Join(
             "|",
@@ -102,7 +103,23 @@ internal static class MongoConventionRegistrar
             conventions.ElementNameConvention.GetType().FullName,
             conventions.IgnoreIfNull,
             conventions.IgnoreExtraElements,
-            additionalConventionTypes,
+            additionalConventions,
             additionalPacks);
     }
+
+    private static string DescribeConvention(IConvention convention)
+    {
+        var type = convention.GetType();
+        var equalsMethod = type.GetMethod(nameof(Equals), [typeof(object)]);
+        var hasValueEquality = equalsMethod is not null && equalsMethod.DeclaringType != typeof(object);
+        return hasValueEquality
+            ? $"{type.FullName}:{convention}"
+            : $"{type.FullName}#{RuntimeHelpers.GetHashCode(convention)}";
+    }
+
+    private static string DescribeFilter(Func<Type, bool> filter) =>
+        $"{filter.Method.DeclaringType?.FullName}.{filter.Method.Name}#{(filter.Target is null ? 0 : RuntimeHelpers.GetHashCode(filter.Target))}";
+
+    private static string DescribePack(AdditionalConventionPack pack) =>
+        $"{pack.Name}:[{string.Join(",", pack.Pack.Conventions.Select(DescribeConvention))}]:{DescribeFilter(pack.Filter)}";
 }

--- a/src/Dilcore.MongoDB/Internal/MongoConventionRegistrar.cs
+++ b/src/Dilcore.MongoDB/Internal/MongoConventionRegistrar.cs
@@ -44,6 +44,15 @@ internal static class MongoConventionRegistrar
                 pack.Add(additional);
             }
 
+            foreach (var additionalPack in conventions.AdditionalPacks)
+            {
+                if (additionalPack.Name == DefaultPackName)
+                {
+                    throw new InvalidOperationException(
+                        $"Convention pack name '{DefaultPackName}' is reserved for the default pack. Choose a different name.");
+                }
+            }
+
             ConventionRegistry.Register(DefaultPackName, pack, _ => true);
 
             var packNames = new List<string> { DefaultPackName };

--- a/src/Dilcore.MongoDB/Internal/MongoConventionRegistrar.cs
+++ b/src/Dilcore.MongoDB/Internal/MongoConventionRegistrar.cs
@@ -1,0 +1,108 @@
+using Dilcore.MongoDB.Descriptors;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Dilcore.MongoDB.Internal;
+
+internal static class MongoConventionRegistrar
+{
+    internal const string DefaultPackName = "Dilcore.MongoDB.DefaultConventions";
+
+    private static readonly object Gate = new();
+    private static string? _registeredSignature;
+    private static IReadOnlyList<string>? _registeredPackNames;
+
+    public static void EnsureRegistered(ConventionsDescriptor conventions)
+    {
+        ArgumentNullException.ThrowIfNull(conventions);
+        var signature = ComputeSignature(conventions);
+
+        if (_registeredSignature is not null)
+        {
+            ThrowIfConflict(_registeredSignature, signature);
+            return;
+        }
+
+        lock (Gate)
+        {
+            if (_registeredSignature is not null)
+            {
+                ThrowIfConflict(_registeredSignature, signature);
+                return;
+            }
+
+            var pack = new ConventionPack
+            {
+                new EnumRepresentationConvention(conventions.EnumRepresentation),
+                conventions.ElementNameConvention,
+                new IgnoreIfNullConvention(conventions.IgnoreIfNull),
+                new IgnoreExtraElementsConvention(conventions.IgnoreExtraElements)
+            };
+
+            foreach (var additional in conventions.AdditionalConventions)
+            {
+                pack.Add(additional);
+            }
+
+            ConventionRegistry.Register(DefaultPackName, pack, _ => true);
+
+            var packNames = new List<string> { DefaultPackName };
+            foreach (var additionalPack in conventions.AdditionalPacks)
+            {
+                ConventionRegistry.Register(additionalPack.Name, additionalPack.Pack, additionalPack.Filter);
+                packNames.Add(additionalPack.Name);
+            }
+
+            _registeredPackNames = packNames;
+            _registeredSignature = signature;
+        }
+    }
+
+    internal static void Reset()
+    {
+        lock (Gate)
+        {
+            if (_registeredPackNames is not null)
+            {
+                foreach (var name in _registeredPackNames)
+                {
+                    ConventionRegistry.Remove(name);
+                }
+            }
+
+            _registeredPackNames = null;
+            _registeredSignature = null;
+        }
+    }
+
+    private static void ThrowIfConflict(string registered, string requested)
+    {
+        if (registered == requested)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Conflicting MongoDB serialization conventions were requested. " +
+            "ConventionRegistry is process-wide; every AddMongoDb call must use the same ConfigureConventions settings. " +
+            $"Already registered: '{registered}'. Requested: '{requested}'.");
+    }
+
+    private static string ComputeSignature(ConventionsDescriptor conventions)
+    {
+        var additionalConventionTypes = string.Join(
+            ",",
+            conventions.AdditionalConventions.Select(c => c.GetType().FullName));
+        var additionalPacks = string.Join(
+            ",",
+            conventions.AdditionalPacks.Select(p => $"{p.Name}:{p.Pack.GetType().FullName}"));
+
+        return string.Join(
+            "|",
+            conventions.EnumRepresentation,
+            conventions.ElementNameConvention.GetType().FullName,
+            conventions.IgnoreIfNull,
+            conventions.IgnoreExtraElements,
+            additionalConventionTypes,
+            additionalPacks);
+    }
+}

--- a/src/Dilcore.MongoDB/Internal/MongoDbCollectionFactory.cs
+++ b/src/Dilcore.MongoDB/Internal/MongoDbCollectionFactory.cs
@@ -6,7 +6,6 @@ using Dilcore.MongoDB.Abstractions.Options;
 using Dilcore.MongoDB.Descriptors;
 using FluentResults;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
 
 namespace Dilcore.MongoDB.Internal;
@@ -16,10 +15,6 @@ internal sealed class MongoDbCollectionFactory(
     IMongoDatabaseResolver databaseResolver,
     INamespaceResolver namespaceResolver) : IMongoDbCollectionFactory
 {
-    private const string DefaultConventions = nameof(DefaultConventions);
-    private static readonly object ConventionLock = new();
-    private static bool _conventionsRegistered;
-
     public async Task<Result<IMongoCollection<TDocument>>> GetCollectionAsync<TDocument>(
         MongoDocumentBindingKey bindingKey,
         CancellationToken cancellationToken = default)
@@ -151,8 +146,6 @@ internal sealed class MongoDbCollectionFactory(
         CancellationToken cancellationToken)
         where TDocument : IDocumentEntity
     {
-        EnsureConventions();
-
         if (string.IsNullOrWhiteSpace(options.CollectionName))
         {
             return Result.Fail("Collection name is not provided");
@@ -175,33 +168,6 @@ internal sealed class MongoDbCollectionFactory(
         }
 
         return Result.Ok(collection);
-    }
-
-    private static void EnsureConventions()
-    {
-        if (_conventionsRegistered)
-        {
-            return;
-        }
-
-        lock (ConventionLock)
-        {
-            if (_conventionsRegistered)
-            {
-                return;
-            }
-
-            var pack = new ConventionPack
-            {
-                new EnumRepresentationConvention(BsonType.String),
-                new CamelCaseElementNameConvention(),
-                new IgnoreIfNullConvention(true),
-                new IgnoreExtraElementsConvention(true)
-            };
-
-            ConventionRegistry.Register(DefaultConventions, pack, _ => true);
-            _conventionsRegistered = true;
-        }
     }
 
     private static async Task CreateTimeToLiveIndexAsync<TDocument>(

--- a/src/Dilcore.MongoDB/PublicAPI.Unshipped.txt
+++ b/src/Dilcore.MongoDB/PublicAPI.Unshipped.txt
@@ -1,1 +1,10 @@
 #nullable enable
+interface Dilcore.MongoDB.DependencyInjection.IConventionsBuilder
+Dilcore.MongoDB.DependencyInjection.IConventionsBuilder.AddConvention(MongoDB.Bson.Serialization.Conventions.IConvention) -> Dilcore.MongoDB.DependencyInjection.IConventionsBuilder
+Dilcore.MongoDB.DependencyInjection.IConventionsBuilder.AddConventionPack(string, MongoDB.Bson.Serialization.Conventions.IConventionPack, System.Func<System.Type, bool>) -> Dilcore.MongoDB.DependencyInjection.IConventionsBuilder
+Dilcore.MongoDB.DependencyInjection.IConventionsBuilder.IgnoreExtraElements(bool) -> Dilcore.MongoDB.DependencyInjection.IConventionsBuilder
+Dilcore.MongoDB.DependencyInjection.IConventionsBuilder.IgnoreIfNull(bool) -> Dilcore.MongoDB.DependencyInjection.IConventionsBuilder
+Dilcore.MongoDB.DependencyInjection.IConventionsBuilder.UseElementNameConvention(MongoDB.Bson.Serialization.Conventions.IConvention) -> Dilcore.MongoDB.DependencyInjection.IConventionsBuilder
+Dilcore.MongoDB.DependencyInjection.IConventionsBuilder.UseEnumRepresentation(MongoDB.Bson.BsonType) -> Dilcore.MongoDB.DependencyInjection.IConventionsBuilder
+Dilcore.MongoDB.DependencyInjection.IMongoDbBuilder.ConfigureConventions(System.Action<Dilcore.MongoDB.DependencyInjection.IConventionsBuilder>) -> Dilcore.MongoDB.DependencyInjection.IMongoDbBuilder
+

--- a/test/IntegrationTests/Infrastructure/V1ParityHarness.cs
+++ b/test/IntegrationTests/Infrastructure/V1ParityHarness.cs
@@ -38,7 +38,8 @@ public static class V1ParityHarness
         {
             Clusters = [],
             Databases = [],
-            Bindings = []
+            Bindings = [],
+            Conventions = ConventionsDescriptor.CreateDefault()
         });
 
         var database = resolver.ResolveAsync(new NamespaceResolutionRequest

--- a/test/Repositories.IntegrationTests/SerializationConventionTests.cs
+++ b/test/Repositories.IntegrationTests/SerializationConventionTests.cs
@@ -1,0 +1,68 @@
+using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Repositories;
+using Dilcore.MongoDB.Extensions;
+using Dilcore.MongoDB.Internal;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Repositories.IntegrationTests;
+
+[NonParallelizable]
+public class SerializationConventionTests : BaseIntegrationTests
+{
+    [SetUp]
+    public void SetUp() => MongoConventionRegistrar.Reset();
+
+    [TearDown]
+    public void TearDown() => MongoConventionRegistrar.Reset();
+
+    [Test]
+    public async Task EnumRepresentation_Int32_StoresEnumAsInt()
+    {
+        var services = new ServiceCollection();
+        var connectionString = MongoDbContainer.GetConnectionString();
+
+        services.AddMongoDb(mongo => mongo
+            .ConfigureConventions(c => c.UseEnumRepresentation(BsonType.Int32))
+            .AddCluster("primary", c => c.UseConnectionString(connectionString))
+            .AddDatabase("EnumConvDB", db =>
+            {
+                db.OnCluster("primary");
+                db.AddDocumentBinding<EnumConventionDocument>("enums", d => d
+                    .WithCollectionName("enumDocs"));
+            }));
+
+        using var provider = AcceptanceServiceProviderFactory.Create(services);
+        using var scope = provider.CreateScope();
+        var repository = scope.ServiceProvider
+            .GetRequiredService<IGenericRepository<EnumConventionDocument>>();
+
+        var store = await repository.StoreAsync(new EnumConventionDocument
+        {
+            Status = EnumConventionStatus.Ready
+        });
+        store.ShouldBeSuccess();
+
+        var client = scope.ServiceProvider.GetRequiredKeyedService<IMongoClient>("primary");
+        var raw = await client
+            .GetDatabase("EnumConvDB")
+            .GetCollection<BsonDocument>("enumDocs")
+            .Find(Builders<BsonDocument>.Filter.Eq("_id", store.Value.Id))
+            .FirstAsync();
+
+        raw["status"].BsonType.ShouldBe(BsonType.Int32);
+        raw["status"].AsInt32.ShouldBe((int)EnumConventionStatus.Ready);
+    }
+
+    public enum EnumConventionStatus
+    {
+        Pending = 0,
+        Ready = 1
+    }
+
+    public sealed class EnumConventionDocument : IDocumentEntity<Guid>
+    {
+        public Guid Id { get; set; }
+        public EnumConventionStatus Status { get; set; }
+    }
+}

--- a/test/UnitTests/ConventionsConfigurationTests.cs
+++ b/test/UnitTests/ConventionsConfigurationTests.cs
@@ -98,7 +98,7 @@ public class ConventionsConfigurationTests
         var ex = Should.Throw<ArgumentException>(() =>
             services.AddMongoDb(mongo => mongo
                 .ConfigureConventions(c => c
-                    .AddConventionPack(MongoConventionRegistrar.DefaultPackName, pack, _ => true))
+                    .AddConventionPack(MongoConventionRegistrar.DefaultPackName.ToUpperInvariant(), pack, _ => true))
                 .AddCluster("primary", c => c.UseConnectionString("mongodb://localhost"))
                 .AddDatabase("app", db =>
                 {
@@ -118,7 +118,7 @@ public class ConventionsConfigurationTests
             AdditionalPacks =
             [
                 new AdditionalConventionPack(
-                    MongoConventionRegistrar.DefaultPackName,
+                    MongoConventionRegistrar.DefaultPackName.ToLowerInvariant(),
                     new ConventionPack(),
                     _ => true)
             ]

--- a/test/UnitTests/ConventionsConfigurationTests.cs
+++ b/test/UnitTests/ConventionsConfigurationTests.cs
@@ -89,6 +89,27 @@ public class ConventionsConfigurationTests
     }
 
     [Test]
+    public void AddMongoDb_ReservedDefaultConventionPackName_Throws()
+    {
+        var services = new ServiceCollection();
+        var pack = new ConventionPack();
+
+        var ex = Should.Throw<ArgumentException>(() =>
+            services.AddMongoDb(mongo => mongo
+                .ConfigureConventions(c => c
+                    .AddConventionPack(MongoConventionRegistrar.DefaultPackName, pack, _ => true))
+                .AddCluster("primary", c => c.UseConnectionString("mongodb://localhost"))
+                .AddDatabase("app", db =>
+                {
+                    db.OnCluster("primary");
+                    db.AddDocumentBinding<TestDoc>("orders", d => d.WithCollectionName("orders"));
+                })));
+
+        ex.ParamName.ShouldBe("name");
+        ex.Message.ShouldContain("reserved");
+    }
+
+    [Test]
     public void AddMongoDb_CalledTwiceWithSameConventions_IsIdempotent()
     {
         var first = new ServiceCollection();
@@ -111,6 +132,39 @@ public class ConventionsConfigurationTests
 
         ex.Message.ShouldContain("Conflicting MongoDB serialization conventions");
         ex.Message.ShouldContain("ConfigureConventions");
+    }
+
+    [Test]
+    public void AddMongoDb_CalledTwiceWithSameCustomConventionInstance_IsIdempotent()
+    {
+        var convention = new IgnoreIfDefaultConvention(true);
+        var pack = new ConventionPack();
+        Func<Type, bool> filter = static _ => true;
+
+        var first = new ServiceCollection();
+        RegisterMinimal(first, mongo => mongo.ConfigureConventions(c => c
+            .AddConvention(convention)
+            .AddConventionPack("custom", pack, filter)));
+
+        var second = new ServiceCollection();
+        Should.NotThrow(() => RegisterMinimal(second, mongo => mongo.ConfigureConventions(c => c
+            .AddConvention(convention)
+            .AddConventionPack("custom", pack, filter))));
+    }
+
+    [Test]
+    public void AddMongoDb_CalledTwiceWithSeparateCustomConventionInstances_Throws()
+    {
+        var first = new ServiceCollection();
+        RegisterMinimal(first, mongo => mongo.ConfigureConventions(c =>
+            c.AddConvention(new IgnoreIfDefaultConvention(true))));
+
+        var second = new ServiceCollection();
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            RegisterMinimal(second, mongo => mongo.ConfigureConventions(c =>
+                c.AddConvention(new IgnoreIfDefaultConvention(true)))));
+
+        ex.Message.ShouldContain("Conflicting MongoDB serialization conventions");
     }
 
     [Test]

--- a/test/UnitTests/ConventionsConfigurationTests.cs
+++ b/test/UnitTests/ConventionsConfigurationTests.cs
@@ -1,0 +1,185 @@
+using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Extensions;
+using Dilcore.MongoDB.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Dilcore.MongoDB.UnitTests;
+
+[NonParallelizable]
+public class ConventionsConfigurationTests
+{
+    [SetUp]
+    public void SetUp() => MongoConventionRegistrar.Reset();
+
+    [TearDown]
+    public void TearDown() => MongoConventionRegistrar.Reset();
+
+    [Test]
+    public void AddMongoDb_WithoutConfigureConventions_UsesDefaultSerialization()
+    {
+        var services = new ServiceCollection();
+        RegisterMinimal(services);
+
+        var bson = Serialize(new DefaultProbeDocument
+        {
+            Status = ProbeStatus.Active,
+            Optional = null
+        });
+
+        bson["status"].BsonType.ShouldBe(BsonType.String);
+        bson["status"].AsString.ShouldBe(nameof(ProbeStatus.Active));
+        bson.Contains("optional").ShouldBeFalse();
+    }
+
+    [Test]
+    public void AddMongoDb_ConfigureConventions_EnumAsInt_SerializesEnumAsInt32()
+    {
+        var services = new ServiceCollection();
+        RegisterMinimal(services, mongo => mongo.ConfigureConventions(c =>
+            c.UseEnumRepresentation(BsonType.Int32)));
+
+        var bson = Serialize(new Int32ProbeDocument { Status = ProbeStatus.Inactive });
+
+        bson["status"].BsonType.ShouldBe(BsonType.Int32);
+        bson["status"].AsInt32.ShouldBe((int)ProbeStatus.Inactive);
+    }
+
+    [Test]
+    public void AddMongoDb_ConfigureConventionsCalledTwice_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            services.AddMongoDb(mongo => mongo
+                .ConfigureConventions(_ => { })
+                .ConfigureConventions(_ => { })
+                .AddCluster("primary", c => c.UseConnectionString("mongodb://localhost"))
+                .AddDatabase("app", db =>
+                {
+                    db.OnCluster("primary");
+                    db.AddDocumentBinding<TestDoc>("orders", d => d.WithCollectionName("orders"));
+                })));
+
+        ex.Message.ShouldContain("ConfigureConventions");
+    }
+
+    [Test]
+    public void AddMongoDb_DuplicateConventionPackName_Throws()
+    {
+        var services = new ServiceCollection();
+        var pack = new ConventionPack();
+
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            services.AddMongoDb(mongo => mongo
+                .ConfigureConventions(c => c
+                    .AddConventionPack("custom", pack, _ => true)
+                    .AddConventionPack("custom", pack, _ => true))
+                .AddCluster("primary", c => c.UseConnectionString("mongodb://localhost"))
+                .AddDatabase("app", db =>
+                {
+                    db.OnCluster("primary");
+                    db.AddDocumentBinding<TestDoc>("orders", d => d.WithCollectionName("orders"));
+                })));
+
+        ex.Message.ShouldContain("Duplicate convention pack name");
+    }
+
+    [Test]
+    public void AddMongoDb_CalledTwiceWithSameConventions_IsIdempotent()
+    {
+        var first = new ServiceCollection();
+        RegisterMinimal(first);
+
+        var second = new ServiceCollection();
+        Should.NotThrow(() => RegisterMinimal(second));
+    }
+
+    [Test]
+    public void AddMongoDb_CalledTwiceWithConflictingConventions_Throws()
+    {
+        var first = new ServiceCollection();
+        RegisterMinimal(first);
+
+        var second = new ServiceCollection();
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            RegisterMinimal(second, mongo => mongo.ConfigureConventions(c =>
+                c.UseEnumRepresentation(BsonType.Int32))));
+
+        ex.Message.ShouldContain("Conflicting MongoDB serialization conventions");
+        ex.Message.ShouldContain("ConfigureConventions");
+    }
+
+    [Test]
+    public void UseEnumRepresentation_UnsupportedBsonType_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Should.Throw<ArgumentException>(() =>
+            services.AddMongoDb(mongo => mongo
+                .ConfigureConventions(c => c.UseEnumRepresentation(BsonType.Boolean))
+                .AddCluster("primary", c => c.UseConnectionString("mongodb://localhost"))
+                .AddDatabase("app", db =>
+                {
+                    db.OnCluster("primary");
+                    db.AddDocumentBinding<TestDoc>("orders", d => d.WithCollectionName("orders"));
+                })));
+
+        ex.ParamName.ShouldBe("representation");
+    }
+
+    private static void RegisterMinimal(
+        IServiceCollection services,
+        Action<DependencyInjection.IMongoDbBuilder>? configureConventions = null)
+    {
+        services.AddMongoDb(mongo =>
+        {
+            configureConventions?.Invoke(mongo);
+            mongo
+                .AddCluster("primary", c => c.UseConnectionString("mongodb://localhost"))
+                .AddDatabase("app", db =>
+                {
+                    db.OnCluster("primary");
+                    db.AddDocumentBinding<TestDoc>("orders", d => d.WithCollectionName("orders"));
+                });
+        });
+    }
+
+    private static BsonDocument Serialize<T>(T document)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BsonBinaryWriter(stream))
+        {
+            BsonSerializer.Serialize(writer, document);
+        }
+
+        stream.Position = 0;
+        using var reader = new BsonBinaryReader(stream);
+        return BsonSerializer.Deserialize<BsonDocument>(reader);
+    }
+
+    private enum ProbeStatus
+    {
+        Active,
+        Inactive
+    }
+
+    private sealed class DefaultProbeDocument
+    {
+        public ProbeStatus Status { get; set; }
+        public string? Optional { get; set; }
+    }
+
+    private sealed class Int32ProbeDocument
+    {
+        public ProbeStatus Status { get; set; }
+    }
+
+    private sealed class TestDoc : IDocumentEntity<Guid>
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/test/UnitTests/ConventionsConfigurationTests.cs
+++ b/test/UnitTests/ConventionsConfigurationTests.cs
@@ -1,4 +1,5 @@
 using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Descriptors;
 using Dilcore.MongoDB.Extensions;
 using Dilcore.MongoDB.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -107,6 +108,28 @@ public class ConventionsConfigurationTests
 
         ex.ParamName.ShouldBe("name");
         ex.Message.ShouldContain("reserved");
+    }
+
+    [Test]
+    public void EnsureRegistered_ReservedDefaultConventionPackName_ThrowsWithoutRegistering()
+    {
+        var conventions = ConventionsDescriptor.CreateDefault() with
+        {
+            AdditionalPacks =
+            [
+                new AdditionalConventionPack(
+                    MongoConventionRegistrar.DefaultPackName,
+                    new ConventionPack(),
+                    _ => true)
+            ]
+        };
+
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            MongoConventionRegistrar.EnsureRegistered(conventions));
+
+        ex.Message.ShouldContain("reserved");
+
+        Should.NotThrow(() => MongoConventionRegistrar.EnsureRegistered(ConventionsDescriptor.CreateDefault()));
     }
 
     [Test]

--- a/test/UnitTests/NamespacePipelineTests.cs
+++ b/test/UnitTests/NamespacePipelineTests.cs
@@ -12,7 +12,8 @@ public class NamespacePipelineTests
     {
         Clusters = [],
         Databases = [],
-        Bindings = []
+        Bindings = [],
+        Conventions = ConventionsDescriptor.CreateDefault()
     };
 
     [Test]


### PR DESCRIPTION
## Summary

Makes BSON serialization conventions configurable on `AddMongoDb` instead of a hardcoded, process-wide pack registered lazily on first collection resolution.

- New `IMongoDbBuilder.ConfigureConventions` / `IConventionsBuilder` for enum representation, naming, null/extra-element handling, extra `IConvention`s, and named packs
- Registration is eager at `AddMongoDb` (fail-fast on conflicts); identical settings in the same process are idempotent
- Defaults unchanged when unconfigured: enum-as-string, camelCase, ignore-null, ignore-extra-elements
- Design recorded in [ADR 0003](docs/adr/0003-serialization-conventions.md)

## Related issues

Closes #63
Closes #64
Closes #65

Milestone: [M2.6 Configurable Serialization Conventions](https://github.com/Dilcore-Official/Dilcore-MongoDb/milestone/14)

## Checklist

- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Tests added or updated when behavior changes
- [x] Docs / ROADMAP / PublicAPI baselines updated when needed
- [x] No secrets or machine-specific paths committed
- [x] Security-sensitive changes called out for maintainer review

## Test plan

```bash
dotnet test test/UnitTests --configuration Release
dotnet test test/ArchitectureTests --configuration Release
dotnet test test/IntegrationTests --configuration Release
dotnet test test/Repositories.IntegrationTests --configuration Release
dotnet build samples/MongoDb.WebApi.Sample
```

Locally: unit (including `ConventionsConfigurationTests`), architecture, DI acceptance, repository integration (enum-as-int round-trip), and sample build all passed.

## Reviewer notes

Start with ADR 0003, then `IConventionsBuilder` / `MongoConventionRegistrar` / `AddMongoDb` wiring. `ConventionRegistry` is process-wide; conflicting `AddMongoDb` calls throw at startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added process-wide MongoDB BSON serialization convention configuration.
  - Configure enum representation, element naming, null handling, extra-element handling, and custom conventions.
  - Added support for filtered convention packs.
  - Defaults now use string enums, camel-case names, ignored nulls, and ignored extra elements.
  - Added sample note priorities with integer enum serialization.

- **Bug Fixes**
  - Prevented conflicting or duplicate convention registrations with clear validation errors.

- **Documentation**
  - Documented configuration behavior, defaults, limitations, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->