### PR TITLE
Harden Scorecard supply-chain alerts and fix CS9107/TLS defaults

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,22 +17,22 @@ on:
       - '.github/workflows/benchmarks.yml'
 
 permissions:
-  contents: write
-  deployments: write
-  pull-requests: write
+  contents: read
 
 jobs:
   benchmarks:
     name: 🏃 Performance Benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: 🛠️ Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: '10.0.x'
 
@@ -113,9 +113,31 @@ jobs:
               handle.write("\n")
           PY
 
+      - name: 📤 Upload benchmark artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: benchmark-artifacts
+          path: test/Benchmarks/Dilcore.MongoDB.Benchmarks/BenchmarkDotNet.Artifacts
+
+  comment:
+    name: 💬 Benchmark PR comment
+    needs: benchmarks
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: 📥 Download benchmark artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: benchmark-artifacts
+          path: test/Benchmarks/Dilcore.MongoDB.Benchmarks/BenchmarkDotNet.Artifacts
+
       - name: 💬 Publish benchmark PR comment
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           BENCHMARK_SUMMARY_PATH: test/Benchmarks/Dilcore.MongoDB.Benchmarks/BenchmarkDotNet.Artifacts/results/benchmark-summary.md
         with:
@@ -149,14 +171,34 @@ jobs:
               });
             }
 
+  store:
+    name: 📈 Store benchmark result
+    needs: benchmarks
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      deployments: write
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: 📥 Download benchmark artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: benchmark-artifacts
+          path: test/Benchmarks/Dilcore.MongoDB.Benchmarks/BenchmarkDotNet.Artifacts
+
       - name: 📈 Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: Dilcore.MongoDB Benchmarks
           tool: benchmarkdotnet
           output-file-path: test/Benchmarks/Dilcore.MongoDB.Benchmarks/BenchmarkDotNet.Artifacts/results/combined-report-full-compressed.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          auto-push: true
           comment-on-alert: true
           fail-on-alert: false
           alert-threshold: '150%'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
     needs: [architecture]
     permissions:
       contents: read
+      id-token: write
       pull-requests: write
 
     steps:
@@ -163,10 +164,12 @@ jobs:
           path: code-coverage-results.md
 
       - name: ☂️ Upload to Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         if: always()
         with:
-          files: "TestResults/**/coverage.cobertura.xml"
+          disable_search: true
+          fail_ci_if_error: true
+          files: TestResults/coverage-merged/Cobertura.xml
           flags: dotnet
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: Dilcore-Official/Dilcore-MongoDb
+          use_oidc: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: 🛠️ Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: '10.0.x'
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: 📤 Upload TRX
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: architecture-trx
           path: "**/TestResults/**/*.trx"
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: 🛠️ Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: '10.0.x'
 
@@ -82,7 +82,7 @@ jobs:
 
       - name: 📤 Upload TRX
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: di-acceptance-trx
           path: "**/TestResults/**/*.trx"
@@ -98,10 +98,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: 🛠️ Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: '10.0.x'
 
@@ -128,14 +128,14 @@ jobs:
 
       - name: 📤 Upload TRX
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: full-trx
           path: "**/TestResults/**/*.trx"
 
       - name: 📊 Merge coverage reports
         if: always()
-        uses: danielpalme/ReportGenerator-GitHub-Action@5
+        uses: danielpalme/ReportGenerator-GitHub-Action@d3ebf1f760f7d8ab92cc44d9bcfee7ad73722a31 # v5.5.11
         with:
           reports: "TestResults/**/coverage.cobertura.xml"
           targetdir: "TestResults/coverage-merged"
@@ -143,7 +143,7 @@ jobs:
 
       - name: 📈 Coverage summary
         if: always()
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: "TestResults/coverage-merged/Cobertura.xml"
           badge: true
@@ -156,14 +156,14 @@ jobs:
           thresholds: "60 80"
 
       - name: 💬 Post coverage comment to PR
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: always() && github.event_name == 'pull_request'
         with:
           header: dotnet-coverage
           path: code-coverage-results.md
 
       - name: ☂️ Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         if: always()
         with:
           files: "TestResults/**/coverage.cobertura.xml"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,22 +22,22 @@ jobs:
       security-events: write
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: 🛠️ Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: "10.0.x"
 
       - name: 🔧 Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.6
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: csharp
 
       - name: 🏗️ Autobuild
-        uses: github/codeql-action/autobuild@v4.37.6
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
       - name: 🧪 Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.6
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:csharp"

--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -24,15 +24,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: 📦 Install check-jsonschema
-        run: pip install --disable-pip-version-check check-jsonschema
+        run: pip install --disable-pip-version-check check-jsonschema==0.38.0
 
       - name: 🔎 Validate Dependabot config
         run: check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml
@@ -50,9 +50,14 @@ jobs:
 
       - name: ⬇️ Download actionlint
         run: |
-          bash <(curl --proto '=https' --tlsv1.2 -sSf \
-            https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) \
-            1.7.12
+          set -euo pipefail
+          VERSION=1.7.12
+          ARCHIVE="actionlint_${VERSION}_linux_amd64.tar.gz"
+          curl --proto '=https' --tlsv1.2 -sSfL \
+            -o "${ARCHIVE}" \
+            "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/${ARCHIVE}"
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  ${ARCHIVE}" | sha256sum -c -
+          tar -xzf "${ARCHIVE}" actionlint
 
       - name: 🧪 Run actionlint
         run: ./actionlint -color

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: 🔎 Dependency Review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -20,13 +20,14 @@ jobs:
     name: 🚀 Pack & Publish
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # contents: write is required to push the release git tag created by this job.
     permissions:
       contents: write
       packages: write
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -48,7 +49,7 @@ jobs:
           echo "📦 New version: ${NEW_VERSION}"
 
       - name: 🛠️ Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,25 +22,25 @@ jobs:
       actions: read
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: 📊 Run analysis
-        uses: ossf/scorecard-action@v2.4.4
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: 📤 Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: 🛡️ Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v4.37.6
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,5 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Deterministic>true</Deterministic>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>
 </Project>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# Codecov: upload the merged Cobertura report from CI (not Jest).
+coverage:
+  status:
+    project: on
+    patch: on
+
+ignore:
+  - "test/**"
+  - "samples/**"
+
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"
+  require_changes: false

--- a/src/Dilcore.MongoDB.Abstractions/Repositories/BaseMongoDbRepository.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Repositories/BaseMongoDbRepository.cs
@@ -95,7 +95,7 @@ public abstract class BaseMongoDbRepository<TDocument> where TDocument : class, 
         return NotDeletedFilter;
     }
 
-    private Task<Result<IMongoCollection<TDocument>>> GetCollectionAsync(CancellationToken cancellationToken = default)
+    protected Task<Result<IMongoCollection<TDocument>>> GetCollectionAsync(CancellationToken cancellationToken = default)
     {
         return _collectionProvider(cancellationToken);
     }

--- a/src/Dilcore.MongoDB/Internal/MongoClientHolder.cs
+++ b/src/Dilcore.MongoDB/Internal/MongoClientHolder.cs
@@ -1,4 +1,3 @@
-using System.Security.Authentication;
 using Dilcore.MongoDB.Abstractions.Ownership;
 using Dilcore.MongoDB.Descriptors;
 using MongoDB.Bson;
@@ -32,10 +31,6 @@ internal sealed class MongoClientHolder : IDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(descriptor.ConnectionString);
 
         var settings = MongoClientSettings.FromUrl(new MongoUrl(descriptor.ConnectionString));
-        settings.SslSettings = new SslSettings
-        {
-            EnabledSslProtocols = SslProtocols.Tls12
-        };
         settings.MaxConnectionPoolSize = descriptor.MaxConnectionPoolSize;
         settings.MaxConnectionIdleTime = TimeSpan.FromMinutes(MongoDbDefaults.MaxConnectionIdleTimeInMinutes);
 

--- a/src/Dilcore.MongoDB/Repositories/GenericMongoDbRepository.cs
+++ b/src/Dilcore.MongoDB/Repositories/GenericMongoDbRepository.cs
@@ -77,7 +77,7 @@ internal class GenericMongoDbRepository<TDocument>(
         FilterDefinition<TDocument> filter,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var collectionResult = await collectionProvider(cancellationToken);
+        var collectionResult = await GetCollectionAsync(cancellationToken);
         if (collectionResult.IsFailed)
         {
             throw new InvalidOperationException(
@@ -102,7 +102,7 @@ internal class GenericMongoDbRepository<TDocument>(
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
         where TDerived : class, TDocument
     {
-        var collectionResult = await collectionProvider(cancellationToken);
+        var collectionResult = await GetCollectionAsync(cancellationToken);
         if (collectionResult.IsFailed)
         {
             throw new InvalidOperationException(


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to commit SHAs, pin `check-jsonschema==0.38.0`, and SHA256-verify the actionlint download so Scorecard pinned-dependency alerts can clear.
- Scope `GITHUB_TOKEN`: benchmarks default to `contents: read`; PR comments get `pull-requests: write`; storing results on `main` keeps `contents`/`deployments` write. NuGet publish still needs `contents: write` to push git tags.
- Fix CS9107 by using protected `GetCollectionAsync`, stop pinning the MongoDB client to TLS 1.2 only, and enable NuGetAudit (`all` / `low`).

Closes #73

Does not replace #28 (analyzers, format, warnings-as-errors).

## Remaining Scorecard items (not fully fixable in code)
- `nugetCommand` alerts for `dotnet restore` — dismiss after merge (CPM + Dependabot).
- Job-level `contents: write` on nuget-publish (required for tagging).
- Branch protection, required reviews, CII badge, and fuzzing — org/process follow-ups on #73.

## Test plan
- [ ] CI green (architecture, unit, integration)
- [ ] Config validation workflow passes actionlint + schema checks
- [ ] Release build has **0** CS9107 warnings
- [ ] `dotnet list package --vulnerable --include-transitive` reports none
- [ ] After merge + Scorecard run on `main`, pinned-Actions alerts drop; dismiss leftover `nugetCommand` alerts with a CPM/Dependabot comment