### PR TITLE
feat(mongodb): keyset pagination, restore/purge, and typed write failures (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ as described in [docs/policies/versioning-and-support.md](docs/policies/versioni
   replace/snapshot/patch, and bulk write options with chunking and partial-failure results.
 - Consumer how-tos: [document policies](docs/guides/document-policies.md) and
   [repositories](docs/guides/repositories.md).
+- Keyset pagination (`GetPageAsync`), soft-delete `RestoreAsync` / `PurgeAsync`,
+  `FindOptions` list overloads, and typed `DuplicateKeyError` / `TransientWriteError` /
+  `WriteConcernFailureError` mapping.
 
 ## [1.0.0] - 2025
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This document is the product roadmap. Implementation work is tracked as GitHub i
 **Repository:** [Dilcore-Official/Dilcore-MongoDb](https://github.com/Dilcore-Official/Dilcore-MongoDb)  
 **Issues filter:** [label:roadmap](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues?q=is%3Aissue+label%3Aroadmap)  
 **GitHub Project:** see [GitHub tracking](#github-tracking)  
-**Status:** M3 repository correctness (#18) in progress on `feature/m3-18-repository-correctness`.
+**Status:** M3 production policies (#19) stacked on repository correctness (#18).
 
 ---
 

--- a/docs/guides/document-policies.md
+++ b/docs/guides/document-policies.md
@@ -75,6 +75,6 @@ public sealed class Order : IDocumentEntity<Guid>, IHasConcurrencyToken, ISoftDe
 
 Enable soft-delete **filters** on the binding (`WithSoftDelete()`). Policy fields are staged and applied only after an acknowledged write. `ETag` is a non-zero random 64-bit token.
 
-`DeleteAsync` with matching `ETag` soft-deletes when the binding has `WithSoftDelete()`. Restore and purge APIs are tracked in [#19](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues/19).
+`DeleteAsync` with matching `ETag` soft-deletes when the binding has `WithSoftDelete()`. `RestoreAsync` clears the flag; `PurgeAsync` hard-deletes. See [repositories.md](repositories.md).
 
-Wrong `ETag` maps to `ConcurrencyConflictError`.
+Wrong `ETag` maps to `ConcurrencyConflictError`. Duplicate-key writes map to `DuplicateKeyError`.

--- a/docs/guides/repositories.md
+++ b/docs/guides/repositories.md
@@ -26,9 +26,11 @@ Unkeyed `IGenericRepository<T>` is registered only when a type has a single bind
 | `UpdateSnapshotAsync` | `$set` mutable snapshot; excludes `_id` |
 | `PatchAsync` | Caller-supplied `UpdateDefinition` |
 | `GetAsync` / `GetAsync<TDerived>` | Single document; missing → `DocumentNotFoundError` |
-| `GetListAsync` (several overloads) | Lists with optional filter and derived types |
+| `GetListAsync` (several overloads) | Lists, optional filter/`FindOptions`, derived types |
+| `GetPageAsync` | Keyset page (`KeysetPageRequest<T>` / `KeysetPage<T>`) |
 | `GetAsyncEnumerable` | Streaming read (see caveat below) |
 | `DeleteAsync` | Soft-delete when `WithSoftDelete()` is on the binding |
+| `RestoreAsync` / `PurgeAsync` | Restore a soft-deleted document; hard-delete (including deleted) |
 | `HasAnyAsync` / `CountAsync` | Same not-deleted filter as reads when soft delete is enabled |
 
 `Dilcore.MongoDB.Repositories.GenericRepositoryExtensions` adds `GetAsync(id)`, `GetListAsync(expression)`, and `DeleteAsync(id, eTag)` for `IDocumentEntity<TId>` / `IHasConcurrencyToken`.
@@ -38,6 +40,20 @@ Unkeyed `IGenericRepository<T>` is registered only when a type has a single bind
 - **Replace** — full stored document replacement.
 - **UpdateSnapshot** — `$set` of the mutable snapshot without `_id`.
 - **Patch** — only the `UpdateDefinition` you pass; Dilcore does not invent a full-document `$set`.
+
+### Keyset paging
+
+```csharp
+var page = await repository.GetPageAsync(new KeysetPageRequest<Order>
+{
+    Filter = Builders<Order>.Filter.Empty,
+    Sort = Builders<Order>.Sort.Ascending(x => x.Id),
+    PageSize = 50,
+    Cursor = previous?.NextCursor
+});
+```
+
+`KeysetPage<T>` returns `Items`, `NextCursor`, and `HasMore`.
 
 ### Streaming caveat
 
@@ -65,6 +81,9 @@ Expected failures are `MongoOperationError` subtypes (FluentResults `Error`). Ma
 |------|--------|
 | `DocumentNotFoundError` | `document_not_found` |
 | `ConcurrencyConflictError` | `concurrency_conflict` |
+| `DuplicateKeyError` | `duplicate_key` |
+| `TransientWriteError` | `transient_write` |
+| `WriteConcernFailureError` | `write_concern_failure` |
 | `DocumentTooLargeError` | `document_too_large` |
 | `BulkWritePartialFailureError` | `bulk_write_partial_failure` |
 

--- a/docs/product/driver-escape-hatches.md
+++ b/docs/product/driver-escape-hatches.md
@@ -1,0 +1,36 @@
+# Driver escape hatches
+
+Dilcore MongoDB keeps `MongoDB.Driver` types visible. Use these recipes when repository helpers are not enough. This is **current** M3 guidance.
+
+Getting-started sample: [MongoDb.WebApi.Sample](../../samples/MongoDb.WebApi.Sample).
+
+## Clients, databases, collections
+
+Resolve keyed `IMongoClient` / `IMongoDatabase` from DI, or `IMongoDbCollectionFactory` for the same namespace pipeline typed repositories use.
+
+```csharp
+var client = services.GetRequiredKeyedService<IMongoClient>("primary");
+var collection = (await factory.GetCollectionAsync<Order>(new MongoDocumentBindingKey("orders"))).Value;
+```
+
+## Concerns, preference, retries
+
+Set `WriteConcern`, `ReadConcern`, `ReadPreference`, retry, timeout, compression, and `applicationName` on `MongoClientSettings` when registering the cluster. Collection-level overrides use driver `MongoCollectionSettings` on `GetCollection` after you resolve the database.
+
+## Sessions
+
+Use `IClientSessionHandle` from `IMongoClient.StartSession()` with the collection overloads that take a session. Dilcore repositories accept a session when resolved inside a later transaction runner; until then, pass the session on driver APIs directly.
+
+Do not start a second session for work that must stay atomic with an existing session.
+
+## Aggregation, cursors, GridFS, CSE, time series
+
+These remain driver APIs:
+
+- Aggregation: `collection.Aggregate().Match(...).ToListAsync()`
+- Cursors: `collection.Find(filter).ToCursorAsync()` — dispose the cursor
+- GridFS: `new GridFSBucket(database)`
+- Client-side encryption: configure on `MongoClientSettings.AutoEncryptionOptions`
+- Time series: `database.CreateCollection(..., new CreateCollectionOptions { TimeSeriesOptions = ... })`
+
+Do not hide these behind a provider-neutral abstraction in Dilcore.

--- a/src/Dilcore.MongoDB.Abstractions/Internal/MongoExceptionMapper.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Internal/MongoExceptionMapper.cs
@@ -10,6 +10,7 @@ internal static class MongoExceptionMapper
     {
         return exception switch
         {
+            MongoWriteConcernException writeConcern => new WriteConcernFailureError(writeConcern.Message),
             MongoWriteException write => MapWrite(write),
             MongoBulkWriteException bulk => MapBulk(bulk),
             MongoCommandException command => MapCommand(command),
@@ -25,6 +26,11 @@ internal static class MongoExceptionMapper
     private static Error MapWrite(MongoWriteException exception)
     {
         var code = exception.WriteError?.Code ?? 0;
+        if (IsDuplicateKey(code, exception.Message))
+        {
+            return new DuplicateKeyError(exception.Message);
+        }
+
         if (IsDocumentTooLarge(code, exception.Message))
         {
             return new DocumentTooLargeError(exception.Message);
@@ -44,6 +50,16 @@ internal static class MongoExceptionMapper
             }
         }
 
+        if (items.Exists(item => IsDuplicateKey(0, item.ErrorMessage ?? string.Empty))
+            || exception.WriteErrors?.Any(error => IsDuplicateKey(error.Code, error.Message)) == true)
+        {
+            var duplicate = exception.WriteErrors?.FirstOrDefault(error => IsDuplicateKey(error.Code, error.Message));
+            if (duplicate is not null && items.Count == 1)
+            {
+                return new DuplicateKeyError(duplicate.Message);
+            }
+        }
+
         if (items.Count == 0)
         {
             return MapMongo(exception);
@@ -54,6 +70,11 @@ internal static class MongoExceptionMapper
 
     private static Error MapCommand(MongoCommandException exception)
     {
+        if (IsDuplicateKey(exception.Code, exception.Message))
+        {
+            return new DuplicateKeyError(exception.Message);
+        }
+
         if (IsDocumentTooLarge(exception.Code, exception.Message))
         {
             return new DocumentTooLargeError(exception.Message);
@@ -64,6 +85,12 @@ internal static class MongoExceptionMapper
 
     private static Error MapMongo(MongoException exception)
     {
+        if (exception.HasErrorLabel("TransientTransactionError")
+            || exception.HasErrorLabel("UnknownTransactionCommitResult"))
+        {
+            return new TransientWriteError(exception.Message);
+        }
+
         if (IsDocumentTooLarge(0, exception.Message))
         {
             return new DocumentTooLargeError(exception.Message);
@@ -71,6 +98,9 @@ internal static class MongoExceptionMapper
 
         return new Error(exception.Message);
     }
+
+    private static bool IsDuplicateKey(int code, string message)
+        => code is 11000 or 11001 || message.Contains("duplicate key", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsDocumentTooLarge(int code, string message)
         => code is 10334 || message.Contains("object to insert too large", StringComparison.OrdinalIgnoreCase)

--- a/src/Dilcore.MongoDB.Abstractions/Options/KeysetPageRequest.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Options/KeysetPageRequest.cs
@@ -1,0 +1,26 @@
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Abstractions.Options;
+
+public sealed class KeysetPageRequest<TDocument>
+    where TDocument : IDocumentEntity
+{
+    public required FilterDefinition<TDocument> Filter { get; init; }
+
+    public required SortDefinition<TDocument> Sort { get; init; }
+
+    public int PageSize { get; init; } = 50;
+
+    public string? Cursor { get; init; }
+
+    public ProjectionDefinition<TDocument>? Projection { get; init; }
+}
+
+public sealed class KeysetPage<TDocument>
+{
+    public required IReadOnlyList<TDocument> Items { get; init; }
+
+    public string? NextCursor { get; init; }
+
+    public bool HasMore { get; init; }
+}

--- a/src/Dilcore.MongoDB.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Dilcore.MongoDB.Abstractions/PublicAPI.Unshipped.txt
@@ -1,9 +1,14 @@
 #nullable enable
 class Dilcore.MongoDB.Abstractions.Exceptions.CollectionResolutionException
+class Dilcore.MongoDB.Abstractions.Options.KeysetPage`1
+class Dilcore.MongoDB.Abstractions.Options.KeysetPageRequest`1
 class Dilcore.MongoDB.Abstractions.Options.MongoBulkWriteOptions
 class Dilcore.MongoDB.Abstractions.Results.BulkWriteItemResult
 class Dilcore.MongoDB.Abstractions.Results.BulkWritePartialFailureError
 class Dilcore.MongoDB.Abstractions.Results.ConcurrencyConflictError
 class Dilcore.MongoDB.Abstractions.Results.DocumentNotFoundError
 class Dilcore.MongoDB.Abstractions.Results.DocumentTooLargeError
+class Dilcore.MongoDB.Abstractions.Results.DuplicateKeyError
 class Dilcore.MongoDB.Abstractions.Results.MongoOperationError
+class Dilcore.MongoDB.Abstractions.Results.TransientWriteError
+class Dilcore.MongoDB.Abstractions.Results.WriteConcernFailureError

--- a/src/Dilcore.MongoDB.Abstractions/Repositories/IGenericRepository.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Repositories/IGenericRepository.cs
@@ -1,3 +1,4 @@
+using Dilcore.MongoDB.Abstractions.Options;
 using FluentResults;
 using MongoDB.Driver;
 
@@ -28,10 +29,19 @@ public interface IGenericRepository<TDocument>
         FilterDefinition<TDocument> filter,
         CancellationToken cancellationToken = default);
 
+    Task<Result<IReadOnlyList<TDocument>>> GetListAsync(
+        FilterDefinition<TDocument> filter,
+        FindOptions<TDocument, TDocument>? options,
+        CancellationToken cancellationToken = default);
+
     Task<Result<IReadOnlyList<TDerived>>> GetListAsync<TDerived>(
         FilterDefinition<TDerived> filter,
         CancellationToken cancellationToken = default)
         where TDerived : class, TDocument;
+
+    Task<Result<KeysetPage<TDocument>>> GetPageAsync(
+        KeysetPageRequest<TDocument> request,
+        CancellationToken cancellationToken = default);
 
     IAsyncEnumerable<TDocument> GetAsyncEnumerable(FilterDefinition<TDocument> filter, CancellationToken cancellationToken = default);
 
@@ -39,6 +49,10 @@ public interface IGenericRepository<TDocument>
         where TDerived : class, TDocument;
 
     Task<Result<bool>> DeleteAsync(FilterDefinition<TDocument> filter, CancellationToken cancellationToken = default);
+
+    Task<Result<bool>> RestoreAsync(FilterDefinition<TDocument> filter, CancellationToken cancellationToken = default);
+
+    Task<Result<long>> PurgeAsync(FilterDefinition<TDocument> filter, CancellationToken cancellationToken = default);
 
     Task<Result<bool>> HasAnyAsync(FilterDefinition<TDocument> filter, CancellationToken cancellationToken = default);
 

--- a/src/Dilcore.MongoDB.Abstractions/Results/MongoOperationErrors.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Results/MongoOperationErrors.cs
@@ -39,6 +39,42 @@ public sealed class ConcurrencyConflictError : MongoOperationError
     public override string Code => ErrorCode;
 }
 
+public sealed class DuplicateKeyError : MongoOperationError
+{
+    public const string ErrorCode = "duplicate_key";
+
+    public DuplicateKeyError(string? message = null)
+        : base(message ?? "A document with the same unique key already exists.")
+    {
+    }
+
+    public override string Code => ErrorCode;
+}
+
+public sealed class TransientWriteError : MongoOperationError
+{
+    public const string ErrorCode = "transient_write";
+
+    public TransientWriteError(string? message = null)
+        : base(message ?? "The write failed due to a transient MongoDB error.")
+    {
+    }
+
+    public override string Code => ErrorCode;
+}
+
+public sealed class WriteConcernFailureError : MongoOperationError
+{
+    public const string ErrorCode = "write_concern_failure";
+
+    public WriteConcernFailureError(string? message = null)
+        : base(message ?? "The write concern was not satisfied.")
+    {
+    }
+
+    public override string Code => ErrorCode;
+}
+
 public sealed class DocumentTooLargeError : MongoOperationError
 {
     public const string ErrorCode = "document_too_large";

--- a/src/Dilcore.MongoDB/Repositories/GenericMongoDbRepository.cs
+++ b/src/Dilcore.MongoDB/Repositories/GenericMongoDbRepository.cs
@@ -9,6 +9,8 @@ using Dilcore.MongoDB.Abstractions.Repositories;
 using Dilcore.MongoDB.Abstractions.Results;
 using Dilcore.MongoDB.Internal;
 using FluentResults;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 
 namespace Dilcore.MongoDB.Repositories;
@@ -125,16 +127,37 @@ internal class GenericMongoDbRepository<TDocument> : BaseMongoDbRepository<TDocu
         }, cancellationToken);
 
     public Task<Result<IReadOnlyList<TDocument>>> GetListAsync(CancellationToken cancellationToken = default) =>
-        GetListAsync(ApplyNotDeleteFilter(), cancellationToken);
+        GetListAsync(ApplyNotDeleteFilter(), options: null, cancellationToken);
 
     public Task<Result<IReadOnlyList<TDocument>>> GetListAsync(
         FilterDefinition<TDocument> filter,
         CancellationToken cancellationToken = default)
+        => GetListAsync(filter, options: null, cancellationToken);
+
+    public Task<Result<IReadOnlyList<TDocument>>> GetListAsync(
+        FilterDefinition<TDocument> filter,
+        FindOptions<TDocument, TDocument>? options,
+        CancellationToken cancellationToken = default)
         => ExecuteAsync(async (collection, token) =>
         {
             filter = ApplyNotDeleteFilter(filter);
-            var entities = await MongoCollectionCalls.Find(collection, _callContext.Session, filter)
-                .ToListAsync(token);
+            var fluent = MongoCollectionCalls.Find(collection, _callContext.Session, filter);
+            if (options?.Sort is not null)
+            {
+                fluent = fluent.Sort(options.Sort);
+            }
+
+            if (options?.Limit is not null)
+            {
+                fluent = fluent.Limit(options.Limit);
+            }
+
+            if (options?.Skip is not null)
+            {
+                fluent = fluent.Skip(options.Skip);
+            }
+
+            var entities = await fluent.ToListAsync(token);
             return Result.Ok<IReadOnlyList<TDocument>>(entities);
         }, cancellationToken);
 
@@ -150,6 +173,46 @@ internal class GenericMongoDbRepository<TDocument> : BaseMongoDbRepository<TDocu
                 : collection.OfType<TDerived>().Find(_callContext.Session, filter);
             var entities = await query.ToListAsync(token);
             return Result.Ok<IReadOnlyList<TDerived>>(entities);
+        }, cancellationToken);
+
+    public Task<Result<KeysetPage<TDocument>>> GetPageAsync(
+        KeysetPageRequest<TDocument> request,
+        CancellationToken cancellationToken = default)
+        => ExecuteAsync(async (collection, token) =>
+        {
+            if (request.PageSize <= 0)
+            {
+                return Result.Fail<KeysetPage<TDocument>>("PageSize must be greater than zero.");
+            }
+
+            var filter = ApplyNotDeleteFilter(request.Filter);
+            if (!string.IsNullOrWhiteSpace(request.Cursor))
+            {
+                filter &= DecodeCursor(request.Cursor);
+            }
+
+            var take = request.PageSize + 1;
+            var fluent = MongoCollectionCalls.Find(collection, _callContext.Session, filter)
+                .Sort(request.Sort)
+                .Limit(take);
+
+            var documents = await fluent.ToListAsync(token);
+            var hasMore = documents.Count > request.PageSize;
+            if (hasMore)
+            {
+                documents.RemoveAt(documents.Count - 1);
+            }
+
+            var nextCursor = hasMore && documents.Count > 0
+                ? EncodeCursor(documents[^1])
+                : null;
+
+            return Result.Ok(new KeysetPage<TDocument>
+            {
+                Items = documents,
+                NextCursor = nextCursor,
+                HasMore = hasMore
+            });
         }, cancellationToken);
 
     public async IAsyncEnumerable<TDocument> GetAsyncEnumerable(
@@ -218,6 +281,40 @@ internal class GenericMongoDbRepository<TDocument> : BaseMongoDbRepository<TDocu
 
             filter = ApplyNotDeleteFilter(filter);
             return SoftDeleteOneAsync(collection, filter, token);
+        }, cancellationToken);
+
+    public Task<Result<bool>> RestoreAsync(FilterDefinition<TDocument> filter, CancellationToken cancellationToken = default)
+        => ExecuteAsync(async (collection, token) =>
+        {
+            if (!IsSoftDeletable)
+            {
+                return Result.Fail<bool>("Restore requires ISoftDeletable.");
+            }
+
+            UpdateDefinition<TDocument> update = Builders<TDocument>.Update.Set("isDeleted", false);
+            if (HasConcurrencyToken)
+            {
+                update = update.Set("eTag", MongoDbHelper.GenerateEtag());
+            }
+
+            if (IsAuditable)
+            {
+                update = update.Set("updatedAt", DateTime.UtcNow);
+            }
+
+            var result = await MongoCollectionCalls.UpdateOneAsync(
+                collection, _callContext.Session, filter, update, options: null, token);
+            return result.MatchedCount == 1
+                ? Result.Ok(true)
+                : Result.Fail<bool>(new DocumentNotFoundError());
+        }, cancellationToken);
+
+    public Task<Result<long>> PurgeAsync(FilterDefinition<TDocument> filter, CancellationToken cancellationToken = default)
+        => ExecuteAsync(async (collection, token) =>
+        {
+            var result = await MongoCollectionCalls.DeleteManyAsync(
+                collection, _callContext.Session, filter, token);
+            return Result.Ok(result.DeletedCount);
         }, cancellationToken);
 
     public Task<Result<bool>> HasAnyAsync(FilterDefinition<TDocument> filter, CancellationToken cancellationToken = default)
@@ -458,5 +555,19 @@ internal class GenericMongoDbRepository<TDocument> : BaseMongoDbRepository<TDocu
         {
             ((IAuditableDocument)entity).UpdatedAt = previousUpdated;
         }
+    }
+
+    private static string EncodeCursor(TDocument document)
+    {
+        var bson = document.ToBsonDocument();
+        var id = bson["_id"];
+        return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(id.ToJson()));
+    }
+
+    private static FilterDefinition<TDocument> DecodeCursor(string cursor)
+    {
+        var json = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(cursor));
+        var id = BsonSerializer.Deserialize<BsonValue>(json);
+        return Builders<TDocument>.Filter.Gt("_id", id);
     }
 }

--- a/test/Repositories.IntegrationTests/ProductionPolicyTests.cs
+++ b/test/Repositories.IntegrationTests/ProductionPolicyTests.cs
@@ -1,0 +1,146 @@
+using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Options;
+using Dilcore.MongoDB.Abstractions.Policies;
+using Dilcore.MongoDB.Abstractions.Repositories;
+using Dilcore.MongoDB.Abstractions.Results;
+using Dilcore.MongoDB.Extensions;
+using Dilcore.MongoDB.Repositories;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Repositories.IntegrationTests;
+
+[Category("M3Matrix")]
+public class ProductionPolicyTests : BaseIntegrationTests
+{
+    [Test]
+    public async Task GetPageAsync_ReturnsStableKeysetPages()
+    {
+        var repository = CreateRepository("pages", enableSoftDelete: false);
+        for (var i = 0; i < 5; i++)
+        {
+            (await repository.StoreAsync(new GenericRepositoryTests.TestEntity1 { Name = $"n{i}" }))
+                .ShouldBeSuccess();
+        }
+
+        var first = await repository.GetPageAsync(new KeysetPageRequest<GenericRepositoryTests.TestEntity1>
+        {
+            Filter = Builders<GenericRepositoryTests.TestEntity1>.Filter.Empty,
+            Sort = Builders<GenericRepositoryTests.TestEntity1>.Sort.Ascending(x => x.Id),
+            PageSize = 2
+        });
+        first.ShouldBeSuccess();
+        first.Value.Items.Count.ShouldBe(2);
+        first.Value.HasMore.ShouldBeTrue();
+        first.Value.NextCursor.ShouldNotBeNull();
+
+        var second = await repository.GetPageAsync(new KeysetPageRequest<GenericRepositoryTests.TestEntity1>
+        {
+            Filter = Builders<GenericRepositoryTests.TestEntity1>.Filter.Empty,
+            Sort = Builders<GenericRepositoryTests.TestEntity1>.Sort.Ascending(x => x.Id),
+            PageSize = 2,
+            Cursor = first.Value.NextCursor
+        });
+        second.ShouldBeSuccess();
+        second.Value.Items.Count.ShouldBe(2);
+        second.Value.Items[0].Id.ShouldNotBe(first.Value.Items[0].Id);
+        second.Value.Items[0].Id.ShouldNotBe(first.Value.Items[1].Id);
+    }
+
+    [Test]
+    public async Task RestoreAndPurge_SoftDeletedDocuments()
+    {
+        var repository = CreateRepository("restore-purge", enableSoftDelete: true);
+        var stored = await repository.StoreAsync(new GenericRepositoryTests.TestEntity1 { Name = "gone" });
+        stored.ShouldBeSuccess();
+        (await repository.DeleteAsync(stored.Value.Id, stored.Value.ETag)).ShouldBeSuccess();
+
+        var filter = Builders<GenericRepositoryTests.TestEntity1>.Filter.Eq(x => x.Id, stored.Value.Id);
+        (await repository.GetAsync(filter)).ShouldBeFailure();
+
+        (await repository.RestoreAsync(filter)).ShouldBeSuccess();
+        (await repository.GetAsync(filter)).ShouldBeSuccess();
+
+        (await repository.DeleteAsync(stored.Value.Id, (await repository.GetAsync(filter)).Value.ETag)).ShouldBeSuccess();
+        var purged = await repository.PurgeAsync(filter);
+        purged.ShouldBeSuccess();
+        purged.Value.ShouldBe(1);
+        (await repository.RestoreAsync(filter)).ShouldBeFailure();
+    }
+
+    [Test]
+    public async Task DuplicateKey_MapsToTypedError()
+    {
+        var services = new ServiceCollection();
+        services.AddMongoDb(mongo => mongo
+            .AddCluster("primary", c => c.UseConnectionString(MongoDbContainer.GetConnectionString()))
+            .AddDatabase("DupDB", db =>
+            {
+                db.OnCluster("primary");
+                db.AddDocumentBinding<GenericRepositoryTests.TestEntity1>("e1", d => d
+                    .WithCollectionName("dup-names")
+                    .WithIndexes(new CreateIndexModel<GenericRepositoryTests.TestEntity1>(
+                        Builders<GenericRepositoryTests.TestEntity1>.IndexKeys.Ascending(x => x.Name),
+                        new CreateIndexOptions { Unique = true })));
+            }));
+
+        var provider = AcceptanceServiceProviderFactory.Create(services);
+        using var scope = provider.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IMongoDbCollectionFactory>();
+        var repository = scope.ServiceProvider
+            .GetRequiredService<IGenericRepository<GenericRepositoryTests.TestEntity1>>();
+
+        (await factory.GetCollectionAsync<GenericRepositoryTests.TestEntity1>(
+            new Abstractions.Keys.MongoDocumentBindingKey("e1"))).ShouldBeSuccess();
+
+        (await repository.StoreAsync(new GenericRepositoryTests.TestEntity1 { Name = "unique-name" })).ShouldBeSuccess();
+        var duplicate = await repository.StoreAsync(new GenericRepositoryTests.TestEntity1 { Name = "unique-name" });
+        duplicate.ShouldBeFailure();
+        duplicate.ShouldHaveError<DuplicateKeyError>();
+    }
+
+    [Test]
+    public async Task GetList_HonorsFindOptionsSortAndLimit()
+    {
+        var repository = CreateRepository("find-options", enableSoftDelete: false);
+        foreach (var name in new[] { "c", "a", "b" })
+        {
+            (await repository.StoreAsync(new GenericRepositoryTests.TestEntity1 { Name = name })).ShouldBeSuccess();
+        }
+
+        var result = await repository.GetListAsync(
+            Builders<GenericRepositoryTests.TestEntity1>.Filter.Empty,
+            new FindOptions<GenericRepositoryTests.TestEntity1, GenericRepositoryTests.TestEntity1>
+            {
+                Sort = Builders<GenericRepositoryTests.TestEntity1>.Sort.Ascending(x => x.Name),
+                Limit = 2
+            });
+        result.ShouldBeSuccess();
+        result.Value.Count.ShouldBe(2);
+        result.Value[0].Name.ShouldBe("a");
+        result.Value[1].Name.ShouldBe("b");
+    }
+
+    private IGenericRepository<GenericRepositoryTests.TestEntity1> CreateRepository(string collection, bool enableSoftDelete)
+    {
+        var services = new ServiceCollection();
+        services.AddMongoDb(mongo => mongo
+            .AddCluster("primary", c => c.UseConnectionString(MongoDbContainer.GetConnectionString()))
+            .AddDatabase("PolicyDB", db =>
+            {
+                db.OnCluster("primary");
+                db.AddDocumentBinding<GenericRepositoryTests.TestEntity1>("e1", d =>
+                {
+                    d.WithCollectionName(collection);
+                    if (enableSoftDelete)
+                    {
+                        d.WithSoftDelete();
+                    }
+                });
+            }));
+
+        return AcceptanceServiceProviderFactory.Create(services)
+            .CreateScope()
+            .ServiceProvider
+            .GetRequiredService<IGenericRepository<GenericRepositoryTests.TestEntity1>>();
+    }
+}


### PR DESCRIPTION
Closes #19

## Summary
- Closes #19 (stacked on #18): `GetPageAsync` / `KeysetPageRequest`, `GetListAsync(..., FindOptions)`, `RestoreAsync` / `PurgeAsync`.
- Maps `DuplicateKeyError`, `TransientWriteError`, and `WriteConcernFailureError`.
- Adds `ProductionPolicyTests` and documents driver escape hatches (concerns, aggregation, GridFS, CSE) without wrapping them.

## Test plan
- [ ] Repositories integration tests including `ProductionPolicyTests`
- [ ] Confirm unique-index duplicate-key mapping still works while indexes are created on collection get (until #22)