### PR TITLE
feat(mongodb): idempotent provisioning runner outside collection resolution (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ as described in [docs/policies/versioning-and-support.md](docs/policies/versioni
   replace/snapshot/patch, and bulk write options with chunking and partial-failure results.
 - Consumer how-tos: [document policies](docs/guides/document-policies.md) and
   [repositories](docs/guides/repositories.md).
+- Idempotent `IMongoDbProvisioner` (DryRun/Apply + `IProvisioningStep`) outside collection
+  resolution. How-to: [provisioning](docs/guides/provisioning.md).
 
 ## [1.0.0] - 2025
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This document is the product roadmap. Implementation work is tracked as GitHub i
 **Repository:** [Dilcore-Official/Dilcore-MongoDb](https://github.com/Dilcore-Official/Dilcore-MongoDb)  
 **Issues filter:** [label:roadmap](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues?q=is%3Aissue+label%3Aroadmap)  
 **GitHub Project:** see [GitHub tracking](#github-tracking)  
-**Status:** M3 repository correctness (#18) in progress on `feature/m3-18-repository-correctness`.
+**Status:** M3 provisioning runner (#22) stacked on repository correctness (#18).
 
 ---
 

--- a/docs/guides/provisioning.md
+++ b/docs/guides/provisioning.md
@@ -1,0 +1,72 @@
+# Provisioning
+
+**Current.** Declare collections, indexes, and TTL on document bindings. Apply them with `IMongoDbProvisioner` **outside the request hot path**. Collection resolution does not create indexes.
+
+Sample: [MongoDb.WebApi.Sample](../../samples/MongoDb.WebApi.Sample) (`ApplyAsync` at startup).
+
+## Binding declarations
+
+```csharp
+db.AddDocumentBinding<Order>("orders", d => d
+    .WithCollectionName("orders")
+    .WithIndexes(new CreateIndexModel<Order>(
+        Builders<Order>.IndexKeys.Ascending(x => x.Sku),
+        new CreateIndexOptions { Name = "orders_sku" }))
+    .WithCollectionItemsTimeToLive(TimeSpan.FromDays(1), x => x.ExpiresAt));
+```
+
+`WithIndexes` takes `params CreateIndexModel<TDocument>[]`, not raw `IndexKeys` definitions.
+
+`WithCollectionItemsTimeToLive` adds an expire-after index on the selected property when you call `ApplyAsync`.
+
+## Runner
+
+`IMongoDbProvisioner` is registered by `AddMongoDb` (scoped):
+
+```csharp
+var provisioner = scope.ServiceProvider.GetRequiredService<IMongoDbProvisioner>();
+var preview = await provisioner.DryRunAsync();   // Applied == false; Action is would-create or skip
+var applied = await provisioner.ApplyAsync();    // mutates the server; idempotent
+```
+
+`ProvisioningReport` lists `ProvisioningStepResult` (`Name`, `Action`, optional `Details`). Fail closed if `IsFailed`.
+
+Use a deploy job or host startup — not every HTTP request.
+
+## Custom steps
+
+Built-in steps cover collections and indexes from bindings. Register extra work in DI after `AddMongoDb`:
+
+```csharp
+builder.Services.AddSingleton<IProvisioningStep, SampleProvisioningStep>();
+```
+
+```csharp
+public sealed class SampleProvisioningStep : IProvisioningStep
+{
+    public string Name => "sample-metadata";
+
+    public async Task<Result<ProvisioningStepResult>> ExecuteAsync(
+        IMongoDatabaseResolver databaseResolver,
+        bool apply,
+        CancellationToken cancellationToken)
+    {
+        var database = await databaseResolver.GetDatabaseAsync(
+            new MongoDatabaseKey("CapabilitiesDB"),
+            cancellationToken);
+        if (database.IsFailed)
+            return database.ToResult();
+
+        return Result.Ok(new ProvisioningStepResult
+        {
+            Name = Name,
+            Action = apply ? "applied" : "would-apply",
+            Details = database.Value.DatabaseNamespace.DatabaseName
+        });
+    }
+}
+```
+
+Time series collections and other driver-only create options belong here or in a one-off script. Vector indexes remain **planned** (M7).
+
+Production least-privilege for the provisioner identity: [production-mongodb.md](../security/production-mongodb.md).

--- a/samples/MongoDb.WebApi.Sample/MongoDb.WebApi.Sample.http
+++ b/samples/MongoDb.WebApi.Sample/MongoDb.WebApi.Sample.http
@@ -1,6 +1,32 @@
 @MongoDb.WebApi.Sample_HostAddress = http://localhost:5248
 
-GET {{MongoDb.WebApi.Sample_HostAddress}}/weatherforecast/
+GET {{MongoDb.WebApi.Sample_HostAddress}}/weather-forecasts
 Accept: application/json
+
+###
+
+POST {{MongoDb.WebApi.Sample_HostAddress}}/weather-forecasts
+Content-Type: application/json
+
+{
+  "date": "2026-08-28",
+  "temperatureC": 21,
+  "summary": "Mild"
+}
+
+###
+
+GET {{MongoDb.WebApi.Sample_HostAddress}}/notes
+Accept: application/json
+
+###
+
+POST {{MongoDb.WebApi.Sample_HostAddress}}/notes
+Content-Type: application/json
+
+{
+  "text": "hello",
+  "priority": "High"
+}
 
 ###

--- a/samples/MongoDb.WebApi.Sample/Program.cs
+++ b/samples/MongoDb.WebApi.Sample/Program.cs
@@ -1,9 +1,13 @@
+// Getting-started sample: one cluster, two document bindings, CRUD, and startup provisioning.
+// Production hosts should inject a connection string instead of starting Testcontainers here (see D22).
 using Dilcore.MongoDB.Abstractions;
 using Dilcore.MongoDB.Abstractions.Policies;
+using Dilcore.MongoDB.Abstractions.Provisioning;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using Dilcore.MongoDB.Extensions;
 using Dilcore.MongoDB.Repositories;
 using MongoDB.Bson;
+using MongoDB.Driver;
 using Testcontainers.MongoDb;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -29,7 +33,10 @@ builder.Services.AddMongoDb(mongo => mongo
             .WithCollectionName("weatherForecasts")
             .WithSoftDelete()
             .WithBulkRepository()
-            .WithGuidIdGeneration(GuidIdGenerationStrategy.SequentialVersion7));
+            .WithGuidIdGeneration(GuidIdGenerationStrategy.SequentialVersion7)
+            .WithIndexes(new CreateIndexModel<WeatherForecast>(
+                Builders<WeatherForecast>.IndexKeys.Ascending(x => x.Date),
+                new CreateIndexOptions { Name = "weather_date" })));
         // Minimal document: identifier only.
         db.AddDocumentBinding<Note>("notes", d => d
             .WithCollectionName("notes"));
@@ -53,6 +60,13 @@ app.UseHttpsRedirection();
 
 var scopeFactory = app.Services.GetRequiredService<IServiceScopeFactory>();
 using var scope = scopeFactory.CreateScope();
+
+var provisioner = scope.ServiceProvider.GetRequiredService<IMongoDbProvisioner>();
+var provisioned = await provisioner.ApplyAsync();
+if (provisioned.IsFailed)
+{
+    throw new InvalidOperationException(string.Join("; ", provisioned.Errors.Select(e => e.Message)));
+}
 
 var repository = scope.ServiceProvider.GetRequiredService<IGenericBulkRepository<WeatherForecast>>();
 

--- a/src/Dilcore.MongoDB.Abstractions/Provisioning/IMongoDbProvisioner.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Provisioning/IMongoDbProvisioner.cs
@@ -1,0 +1,26 @@
+using FluentResults;
+
+namespace Dilcore.MongoDB.Abstractions.Provisioning;
+
+public interface IMongoDbProvisioner
+{
+    Task<Result<ProvisioningReport>> DryRunAsync(CancellationToken cancellationToken = default);
+
+    Task<Result<ProvisioningReport>> ApplyAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class ProvisioningReport
+{
+    public required bool Applied { get; init; }
+
+    public required IReadOnlyList<ProvisioningStepResult> Steps { get; init; }
+}
+
+public sealed class ProvisioningStepResult
+{
+    public required string Name { get; init; }
+
+    public required string Action { get; init; }
+
+    public string? Details { get; init; }
+}

--- a/src/Dilcore.MongoDB.Abstractions/Provisioning/IProvisioningStep.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Provisioning/IProvisioningStep.cs
@@ -1,0 +1,19 @@
+using Dilcore.MongoDB.Abstractions;
+using FluentResults;
+
+namespace Dilcore.MongoDB.Abstractions.Provisioning;
+
+/// <summary>
+/// Extension step for <see cref="IMongoDbProvisioner"/>. Built-in M3 steps cover
+/// collections and indexes; apps (and later M7 search/vector helpers) register extra
+/// steps in DI without changing the runner.
+/// </summary>
+public interface IProvisioningStep
+{
+    string Name { get; }
+
+    Task<Result<ProvisioningStepResult>> ExecuteAsync(
+        IMongoDatabaseResolver databaseResolver,
+        bool apply,
+        CancellationToken cancellationToken);
+}

--- a/src/Dilcore.MongoDB.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Dilcore.MongoDB.Abstractions/PublicAPI.Unshipped.txt
@@ -1,6 +1,10 @@
 #nullable enable
 class Dilcore.MongoDB.Abstractions.Exceptions.CollectionResolutionException
 class Dilcore.MongoDB.Abstractions.Options.MongoBulkWriteOptions
+interface Dilcore.MongoDB.Abstractions.Provisioning.IMongoDbProvisioner
+interface Dilcore.MongoDB.Abstractions.Provisioning.IProvisioningStep
+class Dilcore.MongoDB.Abstractions.Provisioning.ProvisioningReport
+class Dilcore.MongoDB.Abstractions.Provisioning.ProvisioningStepResult
 class Dilcore.MongoDB.Abstractions.Results.BulkWriteItemResult
 class Dilcore.MongoDB.Abstractions.Results.BulkWritePartialFailureError
 class Dilcore.MongoDB.Abstractions.Results.ConcurrencyConflictError

--- a/src/Dilcore.MongoDB/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Dilcore.MongoDB/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Dilcore.MongoDB.Abstractions;
 using Dilcore.MongoDB.Abstractions.Keys;
 using Dilcore.MongoDB.Abstractions.Namespace;
 using Dilcore.MongoDB.Abstractions.Options;
+using Dilcore.MongoDB.Abstractions.Provisioning;
 using Dilcore.MongoDB.Abstractions.Repositories;
 using Dilcore.MongoDB.DependencyInjection;
 using Dilcore.MongoDB.Descriptors;
@@ -42,6 +43,7 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<MongoRegistrationGraph>()));
         services.AddScoped<IMongoDatabaseResolver, MongoDatabaseResolver>();
         services.AddScoped<IMongoDbCollectionFactory, MongoDbCollectionFactory>();
+        services.AddScoped<IMongoDbProvisioner, MongoDbProvisioner>();
         services.AddScoped<IRepositoryResolver, RepositoryResolver>();
 
         foreach (var resolverType in graph.Databases

--- a/src/Dilcore.MongoDB/Internal/MongoDbCollectionFactory.cs
+++ b/src/Dilcore.MongoDB/Internal/MongoDbCollectionFactory.cs
@@ -140,46 +140,19 @@ internal sealed class MongoDbCollectionFactory(
         }, cancellationToken);
     }
 
-    private static async Task<Result<IMongoCollection<TDocument>>> GetTypedCollectionAsync<TDocument>(
+    private static Task<Result<IMongoCollection<TDocument>>> GetTypedCollectionAsync<TDocument>(
         IMongoDatabase database,
         GetCollectionOptions<TDocument> options,
         CancellationToken cancellationToken)
         where TDocument : IDocumentEntity
     {
+        _ = cancellationToken;
         if (string.IsNullOrWhiteSpace(options.CollectionName))
         {
-            return Result.Fail("Collection name is not provided");
+            return Task.FromResult(Result.Fail<IMongoCollection<TDocument>>("Collection name is not provided"));
         }
 
         var collection = database.GetCollection<TDocument>(options.CollectionName);
-
-        if (options.CollectionItemsTimeToLive.HasValue && options.TimeToLeavePropertySelector is not null)
-        {
-            await CreateTimeToLiveIndexAsync(
-                collection,
-                options.CollectionItemsTimeToLive.Value,
-                options.TimeToLeavePropertySelector,
-                cancellationToken);
-        }
-
-        if (options.Indices is { Count: > 0 })
-        {
-            await collection.Indexes.CreateManyAsync(options.Indices, cancellationToken);
-        }
-
-        return Result.Ok(collection);
-    }
-
-    private static async Task CreateTimeToLiveIndexAsync<TDocument>(
-        IMongoCollection<TDocument> collection,
-        TimeSpan timeToLeave,
-        Expression<Func<TDocument, object>> propertySelector,
-        CancellationToken cancellationToken)
-        where TDocument : IDocumentEntity
-    {
-        var indexKeysDefinition = Builders<TDocument>.IndexKeys.Ascending(propertySelector);
-        var indexOptions = new CreateIndexOptions { ExpireAfter = timeToLeave };
-        var indexModel = new CreateIndexModel<TDocument>(indexKeysDefinition, indexOptions);
-        await collection.Indexes.CreateOneAsync(indexModel, cancellationToken: cancellationToken);
+        return Task.FromResult(Result.Ok(collection));
     }
 }

--- a/src/Dilcore.MongoDB/Internal/MongoDbProvisioner.cs
+++ b/src/Dilcore.MongoDB/Internal/MongoDbProvisioner.cs
@@ -1,0 +1,174 @@
+using System.Linq.Expressions;
+using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Keys;
+using Dilcore.MongoDB.Abstractions.Provisioning;
+using Dilcore.MongoDB.Descriptors;
+using FluentResults;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Internal;
+
+internal sealed class MongoDbProvisioner(
+    MongoRegistrationGraph graph,
+    IMongoDatabaseResolver databaseResolver,
+    IMongoDbCollectionFactory collectionFactory,
+    IEnumerable<IProvisioningStep> extraSteps) : IMongoDbProvisioner
+{
+    private const string LedgerCollection = "_dilcore_provisioning";
+    private const string PlanVersion = "m3-1";
+
+    public Task<Result<ProvisioningReport>> DryRunAsync(CancellationToken cancellationToken = default)
+        => RunAsync(apply: false, cancellationToken);
+
+    public Task<Result<ProvisioningReport>> ApplyAsync(CancellationToken cancellationToken = default)
+        => RunAsync(apply: true, cancellationToken);
+
+    private async Task<Result<ProvisioningReport>> RunAsync(bool apply, CancellationToken cancellationToken)
+    {
+        var steps = new List<ProvisioningStepResult>();
+
+        foreach (var binding in graph.Bindings)
+        {
+            var databaseResult = await databaseResolver.GetDatabaseAsync(binding.DatabaseKey, cancellationToken);
+            if (databaseResult.IsFailed)
+            {
+                return databaseResult.ToResult();
+            }
+
+            var database = databaseResult.Value;
+            var collectionNameResult = await collectionFactory.ResolveCollectionNameAsync(
+                binding.DatabaseKey,
+                binding.CollectionName,
+                binding.NamespacePrefix,
+                cancellationToken);
+            if (collectionNameResult.IsFailed)
+            {
+                return collectionNameResult.ToResult();
+            }
+
+            var collectionName = collectionNameResult.Value;
+            var collections = await (await database.ListCollectionNamesAsync(cancellationToken: cancellationToken))
+                .ToListAsync(cancellationToken);
+            var exists = collections.Contains(collectionName);
+
+            if (!exists)
+            {
+                steps.Add(new ProvisioningStepResult
+                {
+                    Name = $"{binding.Key.Name}:collection",
+                    Action = apply ? "create" : "would-create",
+                    Details = collectionName
+                });
+                if (apply)
+                {
+                    await database.CreateCollectionAsync(collectionName, cancellationToken: cancellationToken);
+                }
+            }
+            else
+            {
+                steps.Add(new ProvisioningStepResult
+                {
+                    Name = $"{binding.Key.Name}:collection",
+                    Action = "skip",
+                    Details = collectionName
+                });
+            }
+
+            var indexModels = binding.Indices ?? Array.Empty<object>();
+            if (indexModels.Count > 0 || binding.CollectionItemsTimeToLive is not null)
+            {
+                var applyIndexes = typeof(MongoDbProvisioner)
+                    .GetMethod(nameof(ApplyIndexesAsync), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+                    .MakeGenericMethod(binding.DocumentType);
+                var task = (Task<Result>)applyIndexes.Invoke(this, [database, collectionName, binding, apply, steps, cancellationToken])!;
+                var indexResult = await task;
+                if (indexResult.IsFailed)
+                {
+                    return indexResult;
+                }
+            }
+        }
+
+        foreach (var extraStep in extraSteps)
+        {
+            var extra = await extraStep.ExecuteAsync(databaseResolver, apply, cancellationToken);
+            if (extra.IsFailed)
+            {
+                return extra.ToResult();
+            }
+
+            steps.Add(extra.Value);
+        }
+
+        if (apply && graph.Databases.Count > 0)
+        {
+            var firstDb = await databaseResolver.GetDatabaseAsync(graph.Databases[0].Key, cancellationToken);
+            if (firstDb.IsSuccess)
+            {
+                var ledger = firstDb.Value.GetCollection<BsonDocument>(LedgerCollection);
+                await ledger.UpdateOneAsync(
+                    Builders<BsonDocument>.Filter.Eq("_id", PlanVersion),
+                    Builders<BsonDocument>.Update
+                        .SetOnInsert("appliedAt", DateTime.UtcNow)
+                        .Set("lastRunAt", DateTime.UtcNow),
+                    new UpdateOptions { IsUpsert = true },
+                    cancellationToken);
+            }
+        }
+
+        return Result.Ok(new ProvisioningReport { Applied = apply, Steps = steps });
+    }
+
+    private async Task<Result> ApplyIndexesAsync<TDocument>(
+        IMongoDatabase database,
+        string collectionName,
+        DocumentBindingDescriptor binding,
+        bool apply,
+        List<ProvisioningStepResult> steps,
+        CancellationToken cancellationToken)
+        where TDocument : class, IDocumentEntity
+    {
+        var collection = database.GetCollection<TDocument>(collectionName);
+        var existing = await (await collection.Indexes.ListAsync(cancellationToken)).ToListAsync(cancellationToken);
+        var existingNames = existing.Select(doc => doc.GetValue("name", "").AsString).ToHashSet(StringComparer.Ordinal);
+
+        var models = new List<CreateIndexModel<TDocument>>();
+        if (binding.Indices is { Count: > 0 })
+        {
+            models.AddRange(binding.Indices.Cast<CreateIndexModel<TDocument>>());
+        }
+
+        if (binding is { CollectionItemsTimeToLive: { } ttl, TimeToLeavePropertySelector: not null })
+        {
+            var selector = (Expression<Func<TDocument, object>>)binding.TimeToLeavePropertySelector;
+            models.Add(new CreateIndexModel<TDocument>(
+                Builders<TDocument>.IndexKeys.Ascending(selector),
+                new CreateIndexOptions { ExpireAfter = ttl, Name = $"{collectionName}_ttl" }));
+        }
+
+        foreach (var model in models)
+        {
+            var name = model.Options?.Name ?? $"index-{models.IndexOf(model)}";
+            var action = existingNames.Contains(name) ? "skip" : apply ? "create" : "would-create";
+            steps.Add(new ProvisioningStepResult
+            {
+                Name = $"{binding.Key.Name}:index:{name}",
+                Action = action
+            });
+        }
+
+        var missing = models.Where(model =>
+        {
+            var name = model.Options?.Name;
+            return name is null || !existingNames.Contains(name);
+        }).ToList();
+
+        if (apply && missing.Count > 0)
+        {
+            await collection.Indexes.CreateManyAsync(missing, cancellationToken);
+        }
+
+        return Result.Ok();
+    }
+}

--- a/test/Repositories.IntegrationTests/ProvisioningRunnerTests.cs
+++ b/test/Repositories.IntegrationTests/ProvisioningRunnerTests.cs
@@ -1,0 +1,80 @@
+using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Keys;
+using Dilcore.MongoDB.Abstractions.Policies;
+using Dilcore.MongoDB.Abstractions.Provisioning;
+using Dilcore.MongoDB.Extensions;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Repositories.IntegrationTests;
+
+[Category("M3Matrix")]
+public class ProvisioningRunnerTests : BaseIntegrationTests
+{
+    [Test]
+    public async Task CollectionFactory_DoesNotCreateIndexesOnGet()
+    {
+        var (provider, bindingKey) = CreateHost("hot-path-indexes");
+        using var scope = provider.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IMongoDbCollectionFactory>();
+        var collection = (await factory.GetCollectionAsync<GenericRepositoryTests.TestEntity1>(bindingKey)).Value;
+        await collection.InsertOneAsync(new GenericRepositoryTests.TestEntity1 { Name = "seed" });
+        var indexes = await (await collection.Indexes.ListAsync()).ToListAsync();
+        indexes.ShouldContain(doc => doc.GetValue("name").AsString == "_id_");
+        indexes.ShouldNotContain(doc => doc.GetValue("name").AsString == "name_unique");
+    }
+
+    [Test]
+    public async Task Provisioner_Apply_IsIdempotent()
+    {
+        var (provider, _) = CreateHost("provision-once");
+        using var scope = provider.CreateScope();
+        var provisioner = scope.ServiceProvider.GetRequiredService<IMongoDbProvisioner>();
+
+        var first = await provisioner.ApplyAsync();
+        first.ShouldBeSuccess();
+        first.Value.Applied.ShouldBeTrue();
+        first.Value.Steps.ShouldContain(step => step.Action == "create");
+
+        var second = await provisioner.ApplyAsync();
+        second.ShouldBeSuccess();
+        second.Value.Steps.ShouldNotContain(step => step.Action == "create");
+        second.Value.Steps.ShouldContain(step => step.Action == "skip");
+    }
+
+    [Test]
+    public async Task Provisioner_DryRun_DoesNotCreateIndexes()
+    {
+        var (provider, bindingKey) = CreateHost("provision-dry");
+        using var scope = provider.CreateScope();
+        var provisioner = scope.ServiceProvider.GetRequiredService<IMongoDbProvisioner>();
+        var factory = scope.ServiceProvider.GetRequiredService<IMongoDbCollectionFactory>();
+
+        var dry = await provisioner.DryRunAsync();
+        dry.ShouldBeSuccess();
+        dry.Value.Applied.ShouldBeFalse();
+        dry.Value.Steps.ShouldContain(step => step.Action == "would-create");
+
+        var collection = (await factory.GetCollectionAsync<GenericRepositoryTests.TestEntity1>(bindingKey)).Value;
+        await collection.InsertOneAsync(new GenericRepositoryTests.TestEntity1 { Name = "seed" });
+        var indexes = await (await collection.Indexes.ListAsync()).ToListAsync();
+        indexes.ShouldNotContain(doc => doc.GetValue("name").AsString == "name_unique");
+    }
+
+    private (ServiceProvider Provider, MongoDocumentBindingKey BindingKey) CreateHost(string collection)
+    {
+        var services = new ServiceCollection();
+        services.AddMongoDb(mongo => mongo
+            .AddCluster("primary", c => c.UseConnectionString(MongoDbContainer.GetConnectionString()))
+            .AddDatabase("ProvisionDB", db =>
+            {
+                db.OnCluster("primary");
+                db.AddDocumentBinding<GenericRepositoryTests.TestEntity1>("e1", d => d
+                    .WithCollectionName(collection)
+                    .WithIndexes(new CreateIndexModel<GenericRepositoryTests.TestEntity1>(
+                        Builders<GenericRepositoryTests.TestEntity1>.IndexKeys.Ascending(x => x.Name),
+                        new CreateIndexOptions { Unique = true, Name = "name_unique" })));
+            }));
+
+        return (AcceptanceServiceProviderFactory.Create(services), new MongoDocumentBindingKey("e1"));
+    }
+}


### PR DESCRIPTION
Closes #22

## Summary
- Closes #22 (stacked on #18): `IMongoDbProvisioner` DryRun/Apply + `IProvisioningStep`.
- Collection factory no longer creates indexes/TTL on hot-path `GetCollection`.
- WebApi sample runs `ApplyAsync` at startup. How-to: `docs/guides/provisioning.md`.

## Test plan
- [ ] `ProvisioningRunnerTests`
- [ ] Confirm collection get does not create indexes; provisioner does