### PR TITLE
feat(mongodb): budgeted multi-document transactions (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ as described in [docs/policies/versioning-and-support.md](docs/policies/versioni
 - Keyset pagination (`GetPageAsync`), soft-delete `RestoreAsync` / `PurgeAsync`,
   `FindOptions` list overloads, and typed `DuplicateKeyError` / `TransientWriteError` /
   `WriteConcernFailureError` mapping.
+- Budgeted multi-document transactions via `IMongoDbTransactionRunner` over
+  `WithTransactionAsync`. How-to: [transactions](docs/guides/transactions.md).
 
 ## [1.0.0] - 2025
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This document is the product roadmap. Implementation work is tracked as GitHub i
 **Repository:** [Dilcore-Official/Dilcore-MongoDb](https://github.com/Dilcore-Official/Dilcore-MongoDb)  
 **Issues filter:** [label:roadmap](https://github.com/Dilcore-Official/Dilcore-MongoDb/issues?q=is%3Aissue+label%3Aroadmap)  
 **GitHub Project:** see [GitHub tracking](#github-tracking)  
-**Status:** M3 production policies (#19) stacked on repository correctness (#18).
+**Status:** M3 transactions (#21) stacked on production policies (#19).
 
 ---
 

--- a/docs/guides/repositories.md
+++ b/docs/guides/repositories.md
@@ -85,6 +85,8 @@ Expected failures are `MongoOperationError` subtypes (FluentResults `Error`). Ma
 | `TransientWriteError` | `transient_write` |
 | `WriteConcernFailureError` | `write_concern_failure` |
 | `DocumentTooLargeError` | `document_too_large` |
+| `CrossClusterOperationError` | `cross_cluster_operation` |
+| `TransactionBudgetExceededError` | `transaction_budget_exceeded` |
 | `BulkWritePartialFailureError` | `bulk_write_partial_failure` |
 
 ```csharp
@@ -93,3 +95,7 @@ if (result.HasError<DocumentNotFoundError>())
 if (result.HasError<ConcurrencyConflictError>())
     return Results.Conflict();
 ```
+
+## Transaction-scoped repositories
+
+Inside `IMongoDbTransactionRunner` callbacks, resolve through `IMongoDbTransactionContext.Repositories` (`IRepositoryResolver`) so work uses the session. See [transactions.md](transactions.md).

--- a/docs/guides/transactions.md
+++ b/docs/guides/transactions.md
@@ -1,0 +1,64 @@
+# Transactions
+
+**Current.** Thin coordination over driver sessions. MongoDB multi-document transactions require a **replica set** (or mongos). Standalone `mongo` cannot run them.
+
+Runnable coverage: `test/Repositories.IntegrationTests/TransactionRunnerTests.cs`. Driver session escape hatch: [driver-escape-hatches.md](../product/driver-escape-hatches.md).
+
+## API
+
+`IMongoDbTransactionRunner` is registered by `AddMongoDb` (scoped). `WithTransactionAsync` is a default-interface alias for `ExecuteAsync`.
+
+```csharp
+var result = await runner.WithTransactionAsync(
+    new MongoClusterKey("primary"),
+    async (tx, ct) =>
+    {
+        var orders = tx.Repositories.GetRepository<Order>("orders");
+        var payments = tx.Repositories.GetRepository<Payment>("payments");
+        var stored = await orders.StoreAsync(order, ct);
+        if (stored.IsFailed)
+            return stored.ToResult();
+
+        var payment = await payments.StoreAsync(new Payment { OrderId = stored.Value.Id }, ct);
+        if (payment.IsFailed)
+            return payment.ToResult();
+
+        return Result.Ok(stored.Value.Id);
+    },
+    new MongoTransactionOptions
+    {
+        MaxOperations = 1_000,
+        MaxEstimatedBytes = 16 * 1024 * 1024,
+        TimeLimit = TimeSpan.FromSeconds(60)
+    });
+```
+
+`IMongoDbTransactionContext`:
+
+- `ClusterKey` — cluster this transaction is bound to
+- `Session` — driver `IClientSessionHandle` for APIs Dilcore does not wrap
+- `Repositories` — `IRepositoryResolver` (same binding keys as DI)
+
+Resolve repositories **from the context**, not from the request scope, so writes join the session.
+
+## Rules
+
+- Do not start a second session inside the callback.
+- Work that targets another cluster is rejected as `CrossClusterOperationError` before dispatch.
+- Returning a failed `Result` aborts the transaction.
+- Callbacks must stay sequential; do not issue parallel operations on the same session.
+
+## Budgets
+
+`MongoTransactionOptions` are **client-side estimates**:
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `MaxOperations` | 1_000 | Count of Dilcore-tracked operations |
+| `MaxEstimatedBytes` | 16 MiB | Estimated payload; **not** a MongoDB “16 MiB total transaction” server cap |
+| `TimeLimit` | 60s | Elapsed wall clock on the client |
+| `DriverOptions` | null | Passed through to the driver `TransactionOptions` |
+
+Exceeding a budget returns `TransactionBudgetExceededError`. MongoDB still enforces its own document size and transaction lifetime limits.
+
+Retry and idempotency remain your responsibility; see [production-mongodb.md](../security/production-mongodb.md).

--- a/src/Dilcore.MongoDB.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Dilcore.MongoDB.Abstractions/PublicAPI.Unshipped.txt
@@ -6,9 +6,15 @@ class Dilcore.MongoDB.Abstractions.Options.MongoBulkWriteOptions
 class Dilcore.MongoDB.Abstractions.Results.BulkWriteItemResult
 class Dilcore.MongoDB.Abstractions.Results.BulkWritePartialFailureError
 class Dilcore.MongoDB.Abstractions.Results.ConcurrencyConflictError
+class Dilcore.MongoDB.Abstractions.Results.CrossClusterOperationError
 class Dilcore.MongoDB.Abstractions.Results.DocumentNotFoundError
 class Dilcore.MongoDB.Abstractions.Results.DocumentTooLargeError
 class Dilcore.MongoDB.Abstractions.Results.DuplicateKeyError
 class Dilcore.MongoDB.Abstractions.Results.MongoOperationError
 class Dilcore.MongoDB.Abstractions.Results.TransientWriteError
+class Dilcore.MongoDB.Abstractions.Results.TransactionBudgetExceededError
 class Dilcore.MongoDB.Abstractions.Results.WriteConcernFailureError
+interface Dilcore.MongoDB.Abstractions.Transactions.IMongoDbTransactionContext
+interface Dilcore.MongoDB.Abstractions.Transactions.IMongoDbTransactionRunner
+class Dilcore.MongoDB.Abstractions.Transactions.MongoTransactionOptions
+

--- a/src/Dilcore.MongoDB.Abstractions/Results/MongoOperationErrors.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Results/MongoOperationErrors.cs
@@ -87,6 +87,30 @@ public sealed class DocumentTooLargeError : MongoOperationError
     public override string Code => ErrorCode;
 }
 
+public sealed class CrossClusterOperationError : MongoOperationError
+{
+    public const string ErrorCode = "cross_cluster_operation";
+
+    public CrossClusterOperationError(string? message = null)
+        : base(message ?? "The operation targets a different MongoDB cluster than the current transaction.")
+    {
+    }
+
+    public override string Code => ErrorCode;
+}
+
+public sealed class TransactionBudgetExceededError : MongoOperationError
+{
+    public const string ErrorCode = "transaction_budget_exceeded";
+
+    public TransactionBudgetExceededError(string? message = null)
+        : base(message ?? "The client-side transaction budget was exceeded.")
+    {
+    }
+
+    public override string Code => ErrorCode;
+}
+
 public sealed class BulkWritePartialFailureError : MongoOperationError
 {
     public const string ErrorCode = "bulk_write_partial_failure";

--- a/src/Dilcore.MongoDB.Abstractions/Transactions/IMongoDbTransactionRunner.cs
+++ b/src/Dilcore.MongoDB.Abstractions/Transactions/IMongoDbTransactionRunner.cs
@@ -1,0 +1,55 @@
+using Dilcore.MongoDB.Abstractions.Keys;
+using Dilcore.MongoDB.Abstractions.Repositories;
+using FluentResults;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Abstractions.Transactions;
+
+public sealed class MongoTransactionOptions
+{
+    public int MaxOperations { get; init; } = 1_000;
+
+    public int MaxEstimatedBytes { get; init; } = 16 * 1024 * 1024;
+
+    public TimeSpan TimeLimit { get; init; } = TimeSpan.FromSeconds(60);
+
+    public TransactionOptions? DriverOptions { get; init; }
+}
+
+public interface IMongoDbTransactionContext
+{
+    MongoClusterKey ClusterKey { get; }
+
+    IClientSessionHandle Session { get; }
+
+    IRepositoryResolver Repositories { get; }
+}
+
+public interface IMongoDbTransactionRunner
+{
+    Task<Result> ExecuteAsync(
+        MongoClusterKey clusterKey,
+        Func<IMongoDbTransactionContext, CancellationToken, Task<Result>> callback,
+        MongoTransactionOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    Task<Result<TResult>> ExecuteAsync<TResult>(
+        MongoClusterKey clusterKey,
+        Func<IMongoDbTransactionContext, CancellationToken, Task<Result<TResult>>> callback,
+        MongoTransactionOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    Task<Result> WithTransactionAsync(
+        MongoClusterKey clusterKey,
+        Func<IMongoDbTransactionContext, CancellationToken, Task<Result>> callback,
+        MongoTransactionOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => ExecuteAsync(clusterKey, callback, options, cancellationToken);
+
+    Task<Result<TResult>> WithTransactionAsync<TResult>(
+        MongoClusterKey clusterKey,
+        Func<IMongoDbTransactionContext, CancellationToken, Task<Result<TResult>>> callback,
+        MongoTransactionOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => ExecuteAsync(clusterKey, callback, options, cancellationToken);
+}

--- a/src/Dilcore.MongoDB/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Dilcore.MongoDB/Extensions/ServiceCollectionExtensions.cs
@@ -4,11 +4,13 @@ using Dilcore.MongoDB.Abstractions.Keys;
 using Dilcore.MongoDB.Abstractions.Namespace;
 using Dilcore.MongoDB.Abstractions.Options;
 using Dilcore.MongoDB.Abstractions.Repositories;
+using Dilcore.MongoDB.Abstractions.Transactions;
 using Dilcore.MongoDB.DependencyInjection;
 using Dilcore.MongoDB.Descriptors;
 using Dilcore.MongoDB.Internal;
 using Dilcore.MongoDB.Namespace;
 using Dilcore.MongoDB.Repositories;
+using Dilcore.MongoDB.Transactions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MongoDB.Driver;
@@ -42,6 +44,7 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<MongoRegistrationGraph>()));
         services.AddScoped<IMongoDatabaseResolver, MongoDatabaseResolver>();
         services.AddScoped<IMongoDbCollectionFactory, MongoDbCollectionFactory>();
+        services.AddScoped<IMongoDbTransactionRunner, MongoDbTransactionRunner>();
         services.AddScoped<IRepositoryResolver, RepositoryResolver>();
 
         foreach (var resolverType in graph.Databases

--- a/src/Dilcore.MongoDB/Internal/TransactionBudgetGuard.cs
+++ b/src/Dilcore.MongoDB/Internal/TransactionBudgetGuard.cs
@@ -1,0 +1,42 @@
+using Dilcore.MongoDB.Abstractions.Internal;
+using Dilcore.MongoDB.Abstractions.Results;
+using Dilcore.MongoDB.Abstractions.Transactions;
+using FluentResults;
+
+namespace Dilcore.MongoDB.Internal;
+
+internal sealed class TransactionBudgetGuard(MongoTransactionOptions options) : ITransactionBudgetGuard
+{
+    private int _operations;
+    private int _bytes;
+    private readonly DateTime _deadline = DateTime.UtcNow + options.TimeLimit;
+
+    public void ResetAttempt()
+    {
+        _operations = 0;
+        _bytes = 0;
+    }
+
+    public Result Reserve(int estimatedBytes)
+    {
+        if (DateTime.UtcNow > _deadline)
+        {
+            return Result.Fail(new TransactionBudgetExceededError("The transaction elapsed-time budget was exceeded."));
+        }
+
+        if (_operations + 1 > options.MaxOperations)
+        {
+            return Result.Fail(new TransactionBudgetExceededError("The transaction operation budget was exceeded."));
+        }
+
+        if (_bytes + estimatedBytes > options.MaxEstimatedBytes)
+        {
+            return Result.Fail(new TransactionBudgetExceededError(
+                "The estimated BSON byte budget was exceeded. Totals are client estimates; MongoDB has no 16 MiB total-transaction cap."));
+        }
+
+        _operations++;
+        _bytes += estimatedBytes;
+        return Result.Ok();
+    }
+}

--- a/src/Dilcore.MongoDB/Repositories/TransactionalRepositoryResolver.cs
+++ b/src/Dilcore.MongoDB/Repositories/TransactionalRepositoryResolver.cs
@@ -1,0 +1,112 @@
+using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Keys;
+using Dilcore.MongoDB.Abstractions.Options;
+using Dilcore.MongoDB.Abstractions.Repositories;
+using Dilcore.MongoDB.Abstractions.Results;
+using Dilcore.MongoDB.Descriptors;
+using Dilcore.MongoDB.Internal;
+using System.Linq.Expressions;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Repositories;
+
+internal sealed class TransactionalRepositoryResolver(
+    IMongoDbCollectionFactory collectionFactory,
+    MongoRegistrationGraph graph,
+    MongoCallContext callContext) : IRepositoryResolver
+{
+    public IGenericRepository<TDocument> GetRepository<TDocument>()
+        where TDocument : class, IDocumentEntity
+        => CreateRepository<TDocument>(ResolveSingleBinding<TDocument>());
+
+    public IGenericRepository<TDocument> GetRepository<TDocument>(string bindingKey)
+        where TDocument : class, IDocumentEntity
+        => CreateRepository<TDocument>(graph.GetBinding(new MongoDocumentBindingKey(bindingKey)));
+
+    public IGenericBulkRepository<TDocument> GetBulkRepository<TDocument>()
+        where TDocument : class, IDocumentEntity
+        => CreateBulk<TDocument>(ResolveSingleBinding<TDocument>());
+
+    public IGenericBulkRepository<TDocument> GetBulkRepository<TDocument>(string bindingKey)
+        where TDocument : class, IDocumentEntity
+        => CreateBulk<TDocument>(graph.GetBinding(new MongoDocumentBindingKey(bindingKey)));
+
+    public IGenericProjectionRepository<TDocument> GetProjectionRepository<TDocument>()
+        where TDocument : class, IDocumentEntity
+        => CreateProjection<TDocument>(ResolveSingleBinding<TDocument>());
+
+    public IGenericProjectionRepository<TDocument> GetProjectionRepository<TDocument>(string bindingKey)
+        where TDocument : class, IDocumentEntity
+        => CreateProjection<TDocument>(graph.GetBinding(new MongoDocumentBindingKey(bindingKey)));
+
+    private DocumentBindingDescriptor ResolveSingleBinding<TDocument>()
+    {
+        var matches = graph.Bindings.Where(binding => binding.DocumentType == typeof(TDocument)).ToList();
+        if (matches.Count != 1)
+        {
+            throw new InvalidOperationException(
+                $"Unkeyed repository for '{typeof(TDocument).Name}' requires exactly one binding.");
+        }
+
+        return matches[0];
+    }
+
+    private MongoCallContext BindContext(DocumentBindingDescriptor binding)
+    {
+        var cluster = graph.GetDatabase(binding.DatabaseKey).ClusterKey;
+        if (callContext.Cluster is not null && !callContext.Cluster.Key.Equals(cluster))
+        {
+            throw new CrossClusterRejectedException(cluster.Name);
+        }
+
+        return callContext;
+    }
+
+    private IGenericRepository<TDocument> CreateRepository<TDocument>(DocumentBindingDescriptor binding)
+        where TDocument : class, IDocumentEntity
+        => new GenericMongoDbRepository<TDocument>(
+            CreateOptions<TDocument>(binding),
+            ct => collectionFactory.GetCollectionAsync<TDocument>(binding.Key, ct),
+            BindContext(binding));
+
+    private IGenericBulkRepository<TDocument> CreateBulk<TDocument>(DocumentBindingDescriptor binding)
+        where TDocument : class, IDocumentEntity
+        => new GenericMongoDbBulkRepository<TDocument>(
+            CreateOptions<TDocument>(binding),
+            ct => collectionFactory.GetCollectionAsync<TDocument>(binding.Key, ct),
+            BindContext(binding));
+
+    private IGenericProjectionRepository<TDocument> CreateProjection<TDocument>(DocumentBindingDescriptor binding)
+        where TDocument : class, IDocumentEntity
+        => new GenericMongoDbProjectionRepository<TDocument>(
+            CreateOptions<TDocument>(binding),
+            ct => collectionFactory.GetCollectionAsync<TDocument>(binding.Key, ct),
+            BindContext(binding));
+
+    private static Action<GetCollectionOptions<TDocument>> CreateOptions<TDocument>(DocumentBindingDescriptor binding)
+        where TDocument : class, IDocumentEntity
+        => options =>
+        {
+            options.WithCollectionName(binding.CollectionName);
+            if (binding.SoftDeleteEnabled)
+            {
+                options.WithSoftDelete();
+            }
+
+            options.WithGuidIdGeneration(binding.GuidIdGenerationStrategy);
+            if (binding.Indices is { Count: > 0 })
+            {
+                options.WithIndexes(binding.Indices.Cast<CreateIndexModel<TDocument>>().ToArray());
+            }
+
+            if (binding is { CollectionItemsTimeToLive: { } ttl, TimeToLeavePropertySelector: not null })
+            {
+                options.WithCollectionItemsTimeToLive(
+                    ttl,
+                    (Expression<Func<TDocument, object>>)binding.TimeToLeavePropertySelector);
+            }
+        };
+}
+
+internal sealed class CrossClusterRejectedException(string clusterName)
+    : InvalidOperationException($"Binding targets cluster '{clusterName}', which is outside the current transaction.");

--- a/src/Dilcore.MongoDB/Transactions/MongoDbTransactionRunner.cs
+++ b/src/Dilcore.MongoDB/Transactions/MongoDbTransactionRunner.cs
@@ -1,0 +1,120 @@
+using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Internal;
+using Dilcore.MongoDB.Abstractions.Keys;
+using Dilcore.MongoDB.Abstractions.Repositories;
+using Dilcore.MongoDB.Abstractions.Results;
+using Dilcore.MongoDB.Abstractions.Transactions;
+using Dilcore.MongoDB.Descriptors;
+using Dilcore.MongoDB.Internal;
+using Dilcore.MongoDB.Repositories;
+using FluentResults;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+
+namespace Dilcore.MongoDB.Transactions;
+
+internal sealed class MongoDbTransactionContext : IMongoDbTransactionContext
+{
+    public MongoDbTransactionContext(
+        MongoClusterKey clusterKey,
+        IClientSessionHandle session,
+        IRepositoryResolver repositories)
+    {
+        ClusterKey = clusterKey;
+        Session = session;
+        Repositories = repositories;
+    }
+
+    public MongoClusterKey ClusterKey { get; }
+
+    public IClientSessionHandle Session { get; }
+
+    public IRepositoryResolver Repositories { get; }
+}
+
+internal sealed class MongoDbTransactionRunner(
+    IServiceProvider serviceProvider,
+    MongoRegistrationGraph graph) : IMongoDbTransactionRunner
+{
+    public async Task<Result> ExecuteAsync(
+        MongoClusterKey clusterKey,
+        Func<IMongoDbTransactionContext, CancellationToken, Task<Result>> callback,
+        MongoTransactionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await ExecuteAsync(
+            clusterKey,
+            async (context, token) =>
+            {
+                var inner = await callback(context, token);
+                return inner.IsSuccess ? Result.Ok(true) : Result.Fail<bool>(inner.Errors);
+            },
+            options,
+            cancellationToken);
+        return result.IsSuccess ? Result.Ok() : Result.Fail(result.Errors);
+    }
+
+    public async Task<Result<TResult>> ExecuteAsync<TResult>(
+        MongoClusterKey clusterKey,
+        Func<IMongoDbTransactionContext, CancellationToken, Task<Result<TResult>>> callback,
+        MongoTransactionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        options ??= new MongoTransactionOptions();
+
+        MongoClientHolder holder;
+        try
+        {
+            holder = serviceProvider.GetRequiredKeyedService<MongoClientHolder>(clusterKey.Name);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<TResult>($"Unknown cluster '{clusterKey.Name}'.");
+        }
+
+        using var session = await holder.Client.StartSessionAsync(cancellationToken: cancellationToken);
+        var budget = new TransactionBudgetGuard(options);
+        var factory = serviceProvider.GetRequiredService<IMongoDbCollectionFactory>();
+
+        try
+        {
+            return await session.WithTransactionAsync(async (activeSession, token) =>
+            {
+                budget.ResetAttempt();
+                var callContext = new MongoCallContext
+                {
+                    Session = activeSession,
+                    Budget = budget,
+                    Cluster = new MongoClusterKeyBound { Key = clusterKey }
+                };
+                var repositories = new TransactionalRepositoryResolver(factory, graph, callContext);
+                var context = new MongoDbTransactionContext(clusterKey, activeSession, repositories);
+                var result = await callback(context, token);
+                if (result.IsFailed)
+                {
+                    throw new TransactionCallbackFailedException(result);
+                }
+
+                return result;
+            }, options.DriverOptions, cancellationToken);
+        }
+        catch (TransactionCallbackFailedException exception)
+        {
+            return (Result<TResult>)exception.FailedResult;
+        }
+        catch (CrossClusterRejectedException exception)
+        {
+            return Result.Fail<TResult>(new CrossClusterOperationError(exception.Message));
+        }
+        catch (MongoException exception)
+        {
+            return MongoExceptionMapper.Fail<TResult>(exception);
+        }
+    }
+
+    private sealed class TransactionCallbackFailedException(IResultBase result) : Exception
+    {
+        public IResultBase FailedResult { get; } = result;
+    }
+}

--- a/test/Repositories.IntegrationTests/TransactionRunnerTests.cs
+++ b/test/Repositories.IntegrationTests/TransactionRunnerTests.cs
@@ -1,0 +1,120 @@
+using Dilcore.MongoDB.Abstractions;
+using Dilcore.MongoDB.Abstractions.Keys;
+using Dilcore.MongoDB.Abstractions.Policies;
+using Dilcore.MongoDB.Abstractions.Repositories;
+using Dilcore.MongoDB.Abstractions.Results;
+using Dilcore.MongoDB.Abstractions.Transactions;
+using Dilcore.MongoDB.Extensions;
+using Dilcore.MongoDB.TestSupport;
+using FluentResults;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Testcontainers.MongoDb;
+
+namespace Dilcore.MongoDB.Repositories.IntegrationTests;
+
+[Category("M3Matrix")]
+public class TransactionRunnerTests
+{
+    private MongoDbContainer _replicaSet = null!;
+
+    [OneTimeSetUp]
+    public async Task StartReplicaSet()
+    {
+        _replicaSet = MongoTestImages.CreateReplicaSet();
+        await _replicaSet.StartAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task StopReplicaSet() => await _replicaSet.DisposeAsync();
+
+    [Test]
+    public async Task Transaction_CommitsAcrossTwoCollections()
+    {
+        var (runner, _) = CreateHost();
+        var result = await runner.ExecuteAsync(new MongoClusterKey("primary"), async (tx, ct) =>
+        {
+            var orders = tx.Repositories.GetRepository<Order>("orders");
+            var payments = tx.Repositories.GetRepository<Payment>("payments");
+            (await orders.StoreAsync(new Order { Name = "o1" }, ct)).ShouldBeSuccess();
+            (await payments.StoreAsync(new Payment { Name = "p1" }, ct)).ShouldBeSuccess();
+            return Result.Ok(true);
+        });
+        result.ShouldBeSuccess();
+
+        var (_, provider) = CreateHost();
+        using var scope = provider.CreateScope();
+        var orders = scope.ServiceProvider.GetRequiredKeyedService<IGenericRepository<Order>>("orders");
+        (await orders.HasAnyAsync(Builders<Order>.Filter.Empty)).Value.ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Transaction_UserFailure_Aborts()
+    {
+        var (runner, provider) = CreateHost("abort-db");
+        var result = await runner.ExecuteAsync(new MongoClusterKey("primary"), async (tx, ct) =>
+        {
+            var orders = tx.Repositories.GetRepository<Order>("orders");
+            (await orders.StoreAsync(new Order { Name = "o-abort" }, ct)).ShouldBeSuccess();
+            return Result.Fail<bool>("business rule");
+        });
+        result.ShouldBeFailure();
+
+        using var scope = provider.CreateScope();
+        var orders = scope.ServiceProvider.GetRequiredKeyedService<IGenericRepository<Order>>("orders");
+        (await orders.HasAnyAsync(Builders<Order>.Filter.Eq(x => x.Name, "o-abort"))).Value.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Transaction_Budget_FailsBeforeNextOperation()
+    {
+        var (runner, _) = CreateHost("budget-db");
+        var result = await runner.ExecuteAsync(
+            new MongoClusterKey("primary"),
+            async (tx, ct) =>
+            {
+                var orders = tx.Repositories.GetRepository<Order>("orders");
+                (await orders.StoreAsync(new Order { Name = "one" }, ct)).ShouldBeSuccess();
+                var second = await orders.StoreAsync(new Order { Name = "two" }, ct);
+                second.ShouldBeFailure();
+                second.ShouldHaveError<TransactionBudgetExceededError>();
+                return second.ToResult();
+            },
+            new MongoTransactionOptions { MaxOperations = 1 });
+        result.ShouldBeFailure();
+        result.ShouldHaveError<TransactionBudgetExceededError>();
+    }
+
+    private (IMongoDbTransactionRunner Runner, ServiceProvider Provider) CreateHost(string database = "TxDB")
+    {
+        var services = new ServiceCollection();
+        services.AddMongoDb(mongo => mongo
+            .AddCluster("primary", c => c.UseConnectionString(_replicaSet.GetConnectionString()))
+            .AddDatabase(database, db =>
+            {
+                db.OnCluster("primary");
+                db.AddDocumentBinding<Order>("orders", d => d.WithCollectionName("orders"));
+                db.AddDocumentBinding<Payment>("payments", d => d.WithCollectionName("payments"));
+            }));
+        var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true
+        });
+        return (provider.CreateScope().ServiceProvider.GetRequiredService<IMongoDbTransactionRunner>(), provider);
+    }
+
+    public sealed class Order : IDocumentEntity<Guid>, IHasConcurrencyToken
+    {
+        public Guid Id { get; set; }
+        public long ETag { get; set; }
+        public string? Name { get; set; }
+    }
+
+    public sealed class Payment : IDocumentEntity<Guid>, IHasConcurrencyToken
+    {
+        public Guid Id { get; set; }
+        public long ETag { get; set; }
+        public string? Name { get; set; }
+    }
+}


### PR DESCRIPTION
Closes #21

## Summary
- Closes #21 (stacked on #19): `IMongoDbTransactionRunner` over `WithTransactionAsync`, `TransactionBudgetGuard`, and `TransactionalRepositoryResolver`.
- Typed `CrossClusterOperationError` / `TransactionBudgetExceededError`.
- How-to: `docs/guides/transactions.md`. Session-aware ops come from #18.

## Test plan
- [ ] `TransactionRunnerTests` on replica-set MongoDB
- [ ] Budget exceeded and cross-cluster failure paths